### PR TITLE
fix: implement designers listing page

### DIFF
--- a/app/designers/page.tsx
+++ b/app/designers/page.tsx
@@ -1,0 +1,15 @@
+export const dynamic = 'force-dynamic'
+
+import DesignersGrid from '@/components/ai/DesignersGrid'
+
+export default function DesignersPage() {
+  return (
+    <main className="max-w-3xl mx-auto px-4 py-12 space-y-8">
+      <header>
+        <h1 className="font-display text-4xl leading-[1.05] mb-4">Meet our designers</h1>
+        <p className="text-sm text-[var(--ink-subtle)] max-w-md">Choose a style lens to guide your picks.</p>
+      </header>
+      <DesignersGrid />
+    </main>
+  )
+}


### PR DESCRIPTION
## Summary
- add server page for /designers to render available AI designers

## Testing
- `npm test` *(fails: No test suite found in file /workspace/colrvia/e2e/smoke.spec.ts, No test suite found in file /workspace/colrvia/tests/designers-redirect.test.ts, etc.)*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689a57113af083229b7456afc95ccbc9