### PR TITLE
feat(onboarding): gate additional designers behind Pro

### DIFF
--- a/app/(shell)/start/page.tsx
+++ b/app/(shell)/start/page.tsx
@@ -1,5 +1,6 @@
 import Link from 'next/link'
 import BillingSoonNotice from './BillingSoonNotice'
+import { DEFAULT_DESIGNER_ID } from '@/lib/ai/designers'
 
 export default function StartPage(){
   return (
@@ -7,9 +8,10 @@ export default function StartPage(){
       <BillingSoonNotice />
       <header>
         <h1 className="font-display text-4xl leading-[1.05] mb-4">Start</h1>
-	<p className="text-sm text-[var(--color-fg-muted)] max-w-md">Choose a designer to begin your preferences interview.</p>
+        <p className="text-sm text-[var(--color-fg-muted)] max-w-md">We’ll guide you with our default designer. You can explore other voices later.</p>
       </header>
-      <Link href="/designers" className="btn btn-primary w-full sm:w-auto">Choose your designer</Link>
+      <Link href={`/preferences/${DEFAULT_DESIGNER_ID}`} className="btn btn-primary w-full sm:w-auto">Get my palette</Link>
+      <p className="text-xs text-[var(--ink-subtle)]">Want to meet all designers? <Link href="/designers" className="underline">See them here</Link>.</p>
     </main>
   )
 }

--- a/components/ai/DesignersGrid.tsx
+++ b/components/ai/DesignersGrid.tsx
@@ -15,8 +15,9 @@ export default function DesignersGrid(){
           <div className="text-5xl mb-3" aria-hidden>{d.avatar}</div>
           <h2 className="text-xl font-medium">{d.name}</h2>
           <p className="text-sm text-[var(--ink-subtle)] mb-4">{d.tagline}</p>
+          {d.pro && <span className="inline-flex items-center gap-1 text-[10px] uppercase tracking-wide bg-black text-white px-2 py-1 rounded-full w-fit mb-3">Pro</span>}
           <div className="mt-auto">
-            <Button as={Link} href={`/start/preferences?designerId=${d.id}`} className="w-full" onClick={()=> track('designer_select',{ designerId: d.id })} aria-label={`Start with ${d.name}`}>
+            <Button as={Link} href={`/preferences/${d.id}`} className="w-full" onClick={()=> track('designer_select',{ designerId: d.id })} aria-label={`Start with ${d.name}`}>
               Start with {d.short}
             </Button>
           </div>

--- a/components/paywall/UpgradeButton.tsx
+++ b/components/paywall/UpgradeButton.tsx
@@ -1,0 +1,30 @@
+"use client"
+import { useState } from "react"
+
+export function UpgradeButton({ className }: { className?: string }) {
+  const [busy, setBusy] = useState(false)
+  const go = async () => {
+    try {
+      setBusy(true)
+      const res = await fetch('/api/checkout', { method: 'POST' })
+      if (res.status === 401) {
+        window.location.href = '/sign-in?next=' + encodeURIComponent(window.location.pathname)
+        return
+      }
+      const json = await res.json()
+      if (json?.url) window.location.href = json.url
+      else alert('Unable to start checkout.')
+    } catch (e) {
+      console.error(e)
+      alert('Checkout error')
+    } finally {
+      setBusy(false)
+    }
+  }
+  return (
+    <button onClick={go} disabled={busy} className={className || 'btn btn-primary'}>
+      {busy ? 'Redirecting…' : 'Upgrade to Pro'}
+    </button>
+  )
+}
+

--- a/lib/ai/designers.ts
+++ b/lib/ai/designers.ts
@@ -6,6 +6,7 @@ export type Designer = {
   style: string; // prompt style or description
   short: string; // short CTA label
   heroImage: string; // path to hero image asset
+  pro?: boolean;    // gated behind subscription if true
 };
 
 export const designers: Designer[] = [
@@ -16,16 +17,18 @@ export const designers: Designer[] = [
     tagline: 'Warm, validating, gently curious.',
     style: 'warm, validating, one sentence acknowledgement then one short question',
     short: 'Therapist',
-    heroImage: '/designers/therapist.svg'
+    heroImage: '/designers/therapist.svg',
+    pro: false
   },
   {
     id: 'minimalist',
-    name: 'Bold Minimalist',
-    avatar: '🧊',
-    tagline: 'Clean, calm, straight to the point.',
+    name: 'Mae the Minimalist',
+    avatar: '🧼',
+    tagline: 'Clean, airy, decisive.',
     style: 'succinct, structured, minimalist, offers 1 concise suggestion at a time',
     short: 'Mae',
-    heroImage: '/designers/minimalist.svg'
+    heroImage: '/designers/minimalist.svg',
+    pro: true
   },
   {
     id: 'naturalist',
@@ -34,8 +37,18 @@ export const designers: Designer[] = [
     tagline: 'Friendly, calm, nature-inspired.',
     style: 'friendly, calm, nature-inspired, simple and soothing',
     short: 'Naturalist',
-    heroImage: '/designers/naturalist.svg'
+    heroImage: '/designers/naturalist.svg',
+    pro: true
   }
 ];
 
 export const getDesigner = (id: string) => designers.find(d => d.id === id) || designers[0];
+
+export const DEFAULT_DESIGNER_ID = 'therapist';
+
+export function isDesignerLocked(tier: 'free'|'pro', designerId: string){
+  const d = getDesigner(designerId);
+  if (!d) return false;
+  if (tier === 'pro') return false;
+  return !!d.pro;
+}

--- a/tests/ui/designers-config.test.ts
+++ b/tests/ui/designers-config.test.ts
@@ -1,11 +1,21 @@
 import { describe, it, expect } from 'vitest'
-import { designers } from '@/lib/ai/designers'
+import { designers, DEFAULT_DESIGNER_ID, isDesignerLocked } from '@/lib/ai/designers'
 
 describe('designers config', () => {
   it('each designer has a heroImage', () => {
     for (const d of designers) {
       expect(typeof d.heroImage).toBe('string')
       expect(d.heroImage.length).toBeGreaterThan(0)
+    }
+  })
+  it('has a default designer and gating works', () => {
+    const def = designers.find(d=>d.id===DEFAULT_DESIGNER_ID)
+    expect(def).toBeTruthy()
+    expect(def?.pro).toBeFalsy()
+    const proOne = designers.find(d=>d.pro)
+    if (proOne) {
+      expect(isDesignerLocked('free', proOne.id)).toBe(true)
+      expect(isDesignerLocked('pro', proOne.id)).toBe(false)
     }
   })
 })


### PR DESCRIPTION
## Summary
- default onboarding uses therapist designer and links to others
- show Pro badge on premium designers and upsell in preferences
- add UpgradeButton for checkout

## Testing
- `npm test` *(fails: No test suite found, expected 201 to be 200, etc.)*
- `npm run build` *(fails: Cannot find name 'fallback')*


------
https://chatgpt.com/codex/tasks/task_e_689a60e9a62c8322989a17043f6ca9a9