### PR TITLE
Use preferences alias for designer selection

### DIFF
--- a/app/(shell)/layout.tsx
+++ b/app/(shell)/layout.tsx
@@ -1,19 +1,13 @@
 "use client"
 import React from 'react'
-import dynamic from 'next/dynamic'
 import RouteTransition from '@/components/ux/RouteTransition'
-const BottomNav = dynamic(()=> import('@/components/nav/BottomNav'), { ssr:false })
-import { usePathname } from 'next/navigation'
-
-const HIDE_NAV_PREFIXES = ['/start/preferences','/preferences','/start/preview']
+import BottomNav from '@/components/nav/BottomNav'
 
 export default function ShellLayout({ children }: { children: React.ReactNode }){
-  const pathname = usePathname() || '/'
-  const hide = HIDE_NAV_PREFIXES.some(p=> pathname.startsWith(p))
   return (
     <div className="min-h-screen pb-24">
       <RouteTransition>{children}</RouteTransition>
-      {!hide && <BottomNav />}
+      <BottomNav />
     </div>
   )
 }

--- a/components/ai/DesignersCarousel.tsx
+++ b/components/ai/DesignersCarousel.tsx
@@ -87,7 +87,15 @@ export default function DesignersCarousel(){
                     <p className="text-sm md:text-base text-[var(--ink-subtle)] mt-1">{d.tagline}</p>
                     <div className="mt-auto flex items-center justify-between">
                       <div className="text-xs text-[var(--ink-subtle)]">{idx+1} / {designers.length}</div>
-                      <Button as={Link} href={`/onboarding/${d.id}`} className="rounded-full" onClick={()=> track('designer_select',{ designerId:d.id })} aria-label={`Start with ${d.name}`}>Start with {d.short}</Button>
+                      <Button
+                        as={Link}
+                        href={`/start/preferences?designerId=${d.id}`}
+                        className="rounded-full"
+                        onClick={()=> track('designer_select',{ designerId:d.id })}
+                        aria-label={`Choose ${d.name}`}
+                      >
+                        Choose {d.short}
+                      </Button>
                     </div>
                   </div>
                   <div className="absolute right-4 top-4 h-8 w-8 rounded-lg bg-[var(--bg-surface)]/60 backdrop-blur-sm border" aria-hidden />

--- a/tests/ui/bottom-nav-visibility.test.tsx
+++ b/tests/ui/bottom-nav-visibility.test.tsx
@@ -3,18 +3,16 @@ import { describe, it, expect, vi } from 'vitest'
 import { render } from '@testing-library/react'
 
 vi.mock('next/navigation', () => ({
-  usePathname: () => '/preferences/abc',
+  usePathname: () => '/preferences/abc'
 }))
 
 vi.mock('@/components/ux/RouteTransition', () => ({ default: ({children}:{children:React.ReactNode}) => <>{children}</> }))
 
-vi.mock('next/dynamic', () => ({ default: (fn:any)=> fn() }))
-
 import ShellLayout from '@/app/(shell)/layout'
 
 describe('ShellLayout BottomNav visibility', () => {
-  it('hides BottomNav on onboarding paths', () => {
+  it('shows BottomNav on preferences paths', () => {
     const { queryByLabelText } = render(<ShellLayout><div>content</div></ShellLayout>)
-    expect(queryByLabelText('Primary')).toBeNull()
+    expect(queryByLabelText('Primary')).toBeTruthy()
   })
 })


### PR DESCRIPTION
## Summary
- direct designer carousel selections through `/start/preferences` and label as "Choose"
- always render bottom nav in shell layout so it appears during preferences flow
- adjust unit test to expect bottom nav visibility on preferences paths

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689a6ad849b48322b03e322c70d0d345