### PR TITLE
chore: use npm in CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,17 +14,14 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: 20
-          cache: 'pnpm'
-      - uses: pnpm/action-setup@v4
-        with:
-          version: 9
+          cache: 'npm'
       - name: Install deps
-        run: pnpm install --frozen-lockfile
+        run: npm ci
       - name: Lint
-        run: pnpm lint || pnpm lint --fix || true
+        run: npm run lint || npm run lint -- --fix || true
       - name: Type check
-        run: pnpm tsc --noEmit
+        run: npx tsc --noEmit
       - name: Test
-        run: pnpm test -- --run
+        run: npm test -- --run
       - name: Build
-        run: pnpm build
+        run: npm run build


### PR DESCRIPTION
## Summary
- use npm instead of pnpm in CI to avoid missing executable errors

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689a6c85bf608322abf52d6657e4f9ca