### PR TITLE
Fix designPalette mocks to return Promise in tests

### DIFF
--- a/tests/repair-on-create.test.ts
+++ b/tests/repair-on-create.test.ts
@@ -31,7 +31,10 @@ vi.mock('@/lib/palette/normalize-repair', () => ({ normalizePaletteOrRepair: asy
   { brand:'sherwin_williams', code:'SW 7005', name:'Pure White', hex:'#FEFEFE' },
 ] }))
 
-vi.spyOn(orchestrator, 'designPalette').mockImplementation(()=> ({ swatches: [], placements:{ primary:60, secondary:30, accent:10, trim:5, ceiling:5 } as any }))
+vi.spyOn(orchestrator, 'designPalette').mockResolvedValue({
+  swatches: [],
+  placements: { primary:60, secondary:30, accent:10, trim:5, ceiling:5 } as any,
+})
 vi.spyOn(paletteModule, 'seedPaletteFor').mockImplementation(()=> [])
 
 describe('repair on create', () => {

--- a/tests/story-create-fallback.test.ts
+++ b/tests/story-create-fallback.test.ts
@@ -26,7 +26,10 @@ vi.mock('@/lib/supabase/server', () => ({
 }))
 
 // Mock palette builder to return empty swatches triggering fallback
-vi.spyOn(orchestrator, 'designPalette').mockImplementation(() => ({ swatches: [] as any, placements: { primary:60, secondary:30, accent:10, trim:5, ceiling:5 } as any }))
+vi.spyOn(orchestrator, 'designPalette').mockResolvedValue({
+  swatches: [] as any,
+  placements: { primary:60, secondary:30, accent:10, trim:5, ceiling:5 } as any,
+})
 
 // Mock seedPaletteFor to return empty to force repair code path
 vi.spyOn(paletteModule, 'seedPaletteFor').mockImplementation(() => [])


### PR DESCRIPTION
## Summary
- ensure designPalette mocks resolve with Palette

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689a6ddfa31c8322a64329538b610963