### PR TITLE
feat(ui): animated ambient edge glow using brand tokens

### DIFF
--- a/__tests__/ambient-edge.test.tsx
+++ b/__tests__/ambient-edge.test.tsx
@@ -1,0 +1,15 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import AmbientEdge from '@/components/ui/ambient-edge';
+
+describe('AmbientEdge', () => {
+  it('renders when active', () => {
+    render(<AmbientEdge active />);
+    expect(screen.getByRole('presentation', { hidden: true })).toBeTruthy();
+  });
+
+  it('does not render when inactive', () => {
+    const { queryByTestId } = render(<AmbientEdge active={false} />);
+    expect(document.querySelector('[data-ambient-edge]')).toBeNull();
+  });
+});

--- a/app/globals.css
+++ b/app/globals.css
@@ -116,3 +116,55 @@ a, button, [role="button"] { outline-offset: 3px; }
     scroll-behavior: auto !important;
   }
 }
+
+/* Ambient Edge Glow — brand-aware, motion-safe */
+@keyframes ambient-spin {
+  to { transform: rotate(360deg); }
+}
+
+/* Container element; we draw with a ::before so we can mask the center out */
+[data-ambient-edge]::before {
+  content: "";
+  position: fixed;
+  inset: 0;
+  z-index: 60;
+  pointer-events: none;
+
+  /* Animated conic gradient using brand tokens (shadcn variables) */
+  background:
+    conic-gradient(
+      from 0deg at 50% 50%,
+      hsl(var(--primary)) 0deg 90deg,
+      hsl(var(--accent)) 90deg 180deg,
+      hsl(var(--muted)) 180deg 270deg,
+      hsl(var(--ring)) 270deg 360deg
+    );
+
+  /* Soft glow + spin */
+  opacity: var(--ambient-opacity, 0.6);
+  filter: blur(var(--ambient-blur, 24px));
+  animation: ambient-spin var(--ambient-speed, 18s) linear infinite;
+
+  /* Make it only the edges: mask center out using the content-box trick */
+  padding: var(--ambient-thickness, 24px);
+  border-radius: calc(var(--radius, 0.5rem) + var(--ambient-thickness, 24px));
+
+  /* Two masks: full box minus content-box => a frame */
+  -webkit-mask: linear-gradient(#000 0 0) content-box, linear-gradient(#000 0 0);
+  -webkit-mask-composite: xor;      /* Safari/Chrome */
+          mask-composite: exclude;  /* Firefox */
+
+  /* Respect iOS safe areas a bit more without overcomplicating */
+  /* (optional) uncomment if you want thicker top/bottom around notches:
+  padding-top: calc(var(--ambient-thickness, 24px) + env(safe-area-inset-top));
+  padding-bottom: calc(var(--ambient-thickness, 24px) + env(safe-area-inset-bottom));
+  */
+}
+
+/* Motion safety */
+@media (prefers-reduced-motion: reduce) {
+  [data-ambient-edge]::before {
+    animation: none;
+    opacity: 0.35;
+  }
+}

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -10,6 +10,7 @@ import SupabaseListener from '@/components/providers/SupabaseListener'
 import { ThemeProvider } from 'next-themes'
 import { Analytics } from '@vercel/analytics/react'
 import { MotionProvider } from '@/components/theme/MotionSettings'
+import AmbientEdge from '@/components/ui/ambient-edge'
 import dynamic from 'next/dynamic'
 const RouteTransition = dynamic(() => import('@/components/ux/RouteTransition'), { ssr:false })
 const StartStoryPortalProvider = dynamic(()=> import('@/components/ux/StartStoryPortal').then(m=> m.StartStoryPortalProvider), { ssr:false })
@@ -93,6 +94,13 @@ export default function RootLayout({
   <SupabaseListener />
     </MotionProvider>
   </ThemeProvider>
+  {/* Animated ambient edge glow; reads brand tokens from CSS (shadcn) */}
+  <AmbientEdge
+    thickness={22}
+    blur={26}
+    speedSeconds={16}
+    opacity={0.55}
+  />
       </body>
     </html>
   )

--- a/components/ui/ambient-edge.tsx
+++ b/components/ui/ambient-edge.tsx
@@ -1,0 +1,59 @@
+'use client';
+
+import * as React from 'react';
+import { cn } from '@/lib/utils';
+
+type AmbientEdgeProps = {
+  /** Up to 4 CSS color strings; defaults use brand tokens via CSS vars */
+  colors?: [string?, string?, string?, string?];
+  /** Ring thickness in px */
+  thickness?: number;
+  /** Blur radius in px */
+  blur?: number;
+  /** Spin speed in seconds */
+  speedSeconds?: number;
+  /** 0..1 opacity */
+  opacity?: number;
+  /** Toggle visibility */
+  active?: boolean;
+  className?: string;
+};
+
+export default function AmbientEdge({
+  colors,
+  thickness,
+  blur,
+  speedSeconds,
+  opacity,
+  active = true,
+  className,
+}: AmbientEdgeProps) {
+  if (!active) return null;
+
+  const style: React.CSSProperties = {
+    // Pass CSS vars when props provided; otherwise use defaults set in CSS
+    ...(thickness != null && { ['--ambient-thickness' as any]: `${thickness}px` }),
+    ...(blur != null && { ['--ambient-blur' as any]: `${blur}px` }),
+    ...(speedSeconds != null && { ['--ambient-speed' as any]: `${speedSeconds}s` }),
+    ...(opacity != null && { ['--ambient-opacity' as any]: String(opacity) }),
+  };
+
+  // Optional: allow color overrides (we keep defaults to shadcn vars if not provided)
+  if (colors?.length) {
+    const [c1, c2, c3, c4] = colors;
+    if (c1) (style as any)['--ambient-c1'] = c1;
+    if (c2) (style as any)['--ambient-c2'] = c2;
+    if (c3) (style as any)['--ambient-c3'] = c3;
+    if (c4) (style as any)['--ambient-c4'] = c4;
+  }
+
+  return (
+    <div
+      role="presentation"
+      aria-hidden="true"
+      data-ambient-edge=""
+      className={cn('pointer-events-none fixed inset-0 z-[60]', className)}
+      style={style}
+    />
+  );
+}

--- a/lib/utils/index.ts
+++ b/lib/utils/index.ts
@@ -1,0 +1,8 @@
+import { type ClassValue, clsx } from 'clsx';
+import { twMerge } from 'tailwind-merge';
+
+export function cn(...inputs: ClassValue[]) {
+  return twMerge(clsx(...inputs));
+}
+
+export * from './seededRandom';


### PR DESCRIPTION
## Summary
- add `AmbientEdge` component for animated, motion-safe edge glow
- wire edge glow globally in root layout and expose css mask/variables
- test ambient edge activation

## Testing
- `npm test`
- `npm run build` *(fails: supabaseUrl is required)*

------
https://chatgpt.com/codex/tasks/task_e_689a6da70a3c832288d62d9495b839a5