### PR TITLE
refactor: use color tokens

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -14,15 +14,15 @@ export default function HomePage() {
   const [open, setOpen] = useState(false)
   const startStory = useStartStory()
   return (
-    <main className="relative mx-auto max-w-3xl px-4 py-12 bg-[#404934] text-[#F7F7F2]">
+    <main className="relative mx-auto max-w-3xl px-4 py-12 bg-[var(--olive-700)] text-[var(--cream-50)]">
       <div className="absolute inset-0 pointer-events-none" aria-hidden>
-        <div className="absolute inset-0 opacity-40 bg-[radial-gradient(circle_at_30%_20%,#6d7b5d,transparent_60%),radial-gradient(circle_at_70%_80%,#2d3328,transparent_55%)]" />
-        <div className="absolute inset-0 bg-[linear-gradient(180deg,rgba(64,73,52,0)_0%,#404934_90%)]" />
+        <div className="absolute inset-0 opacity-40 bg-[radial-gradient(circle_at_30%_20%,var(--olive-500),transparent_60%),radial-gradient(circle_at_70%_80%,var(--olive-900),transparent_55%)]" />
+        <div className="absolute inset-0 bg-[linear-gradient(180deg,rgba(64,73,52,0)_0%,var(--olive-700)_90%)]" />
       </div>
       <div className="relative space-y-10">
         <header className="space-y-6">
           <div className="space-y-2">
-            <p className="text-sm uppercase tracking-wide text-[#d1d9ce]">instant color confidence</p>
+            <p className="text-sm uppercase tracking-wide text-[var(--sage-200)]">instant color confidence</p>
             <motion.h1
               initial={{ opacity: 0, y: 20 }}
               animate={{ opacity: 1, y: 0 }}
@@ -31,14 +31,14 @@ export default function HomePage() {
             >
               from vibe to walls in minutes.
               <br />
-              <span className="text-[#f2b897]">real paint codes. clear placements.</span>
+              <span className="text-[var(--peach-300)]">real paint codes. clear placements.</span>
             </motion.h1>
           </div>
           <div className="flex flex-wrap gap-4">
             <button
               type="button"
               onClick={() => setOpen(true)}
-              className="px-5 py-2 rounded-full border border-[#566049] text-sm hover:bg-[#566049]/30 transition"
+              className="px-5 py-2 rounded-full border border-[var(--olive-600)] text-sm hover:bg-[var(--olive-600)]/30 transition"
             >How it works</button>
           </div>
         </header>
@@ -47,7 +47,7 @@ export default function HomePage() {
             href="/designers"
             onClick={(e) => { e.preventDefault(); startStory("/designers") }}
             className="inline-flex items-center justify-center rounded-2xl px-8 py-4 text-xl md:text-2xl font-semibold w-full sm:w-auto hover:opacity-95"
-            style={{ backgroundColor: "#f2b897", color: "#1f2937" }}
+            style={{ backgroundColor: "var(--peach-300)", color: "var(--slate-800)" }}
           >
             Start Color Story
           </Link>

--- a/components/nav/BottomNav.tsx
+++ b/components/nav/BottomNav.tsx
@@ -13,7 +13,7 @@ const TABS = [
 export function BottomNav(){
   const pathname = usePathname() || '/'
   return (
-    <nav aria-label="Primary" className="fixed inset-x-0 bottom-0 z-40 bg-[#404934] text-[#F7F7F2] backdrop-blur">
+    <nav aria-label="Primary" className="fixed inset-x-0 bottom-0 z-40 bg-[var(--olive-700)] text-[var(--cream-50)] backdrop-blur">
       <div className="mx-auto max-w-3xl">
         <ul className="grid grid-cols-3 gap-1 px-2 py-2 pb-[calc(0.5rem+env(safe-area-inset-bottom))]">
           {TABS.map(({ href, label, Icon }) => {

--- a/styles/tokens.css
+++ b/styles/tokens.css
@@ -48,6 +48,16 @@
   --color-success: hsl(150 65% 40%);
   --color-success-fg: #fff;
 
+  /* Home palette */
+  --olive-900: #2d3328;
+  --olive-700: #404934;
+  --olive-600: #566049;
+  --olive-500: #6d7b5d;
+  --sage-200: #d1d9ce;
+  --peach-300: #f2b897;
+  --cream-50: #F7F7F2;
+  --slate-800: #1f2937;
+
   /* Typography */
   --font-sans: 'Inter', system-ui, Avenir, Helvetica, Arial, sans-serif;
   --font-mono: 'Roboto Mono', ui-monospace, SFMono-Regular, Menlo, monospace;
@@ -124,6 +134,16 @@
     --color-accent: hsl(var(--brand-hue) 84% 68%);
     --color-accent-hover: hsl(var(--brand-hue) 84% 62%);
     --color-accent-active: hsl(var(--brand-hue) 84% 56%);
+
+    /* Home palette */
+    --olive-900: #2d3328;
+    --olive-700: #404934;
+    --olive-600: #566049;
+    --olive-500: #6d7b5d;
+    --sage-200: #d1d9ce;
+    --peach-300: #f2b897;
+    --cream-50: #F7F7F2;
+    --slate-800: #1f2937;
+    }
   }
-}
 }


### PR DESCRIPTION
## Summary
- replace hard-coded colors in home page and bottom nav with design tokens
- add palette variables to `styles/tokens.css` for shared usage

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689a6fca28588322ae7cf3b5d81f48ea