### PR TITLE
Default Button component to non-submitting type

### DIFF
--- a/components/ui/Button.tsx
+++ b/components/ui/Button.tsx
@@ -6,7 +6,7 @@ import { clsx } from 'clsx'
 type Variant = 'primary' | 'outline' | 'ghost'
 type Polymorphic = React.ButtonHTMLAttributes<HTMLButtonElement> & { variant?: Variant; as?: any; href?: string }
 
-export default function Button({ className, variant='primary', as:Comp='button', href, ...rest }: Polymorphic) {
+export default function Button({ className, variant='primary', as:Comp='button', href, type, ...rest }: Polymorphic) {
   const base = 'inline-flex items-center justify-center font-medium text-sm rounded-[var(--radius)] px-5 h-11 gap-2 transition-colors ease-[cubic-bezier(.2,.8,.2,1)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-brand disabled:opacity-50 disabled:pointer-events-none shadow-sm'
   const variants = {
     primary: 'bg-brand text-brand-contrast hover:bg-brand-hover',
@@ -14,6 +14,6 @@ export default function Button({ className, variant='primary', as:Comp='button',
     ghost: 'text-ink hover:bg-paper'
   } as const
   const styles = clsx(base, variants[variant], className)
-  if (Comp !== 'button') return <Comp href={href} className={twMerge(styles)} {...rest} />
-  return <button className={twMerge(styles)} {...rest} />
+  if (Comp !== 'button') return <Comp href={href} type={type} className={twMerge(styles)} {...rest} />
+  return <button type={type ?? 'button'} className={twMerge(styles)} {...rest} />
 }

--- a/tests/ui/button.test.tsx
+++ b/tests/ui/button.test.tsx
@@ -7,4 +7,10 @@ describe('Button', () => {
     render(<Button>Click me</Button>)
     expect(screen.getByRole('button', { name: /click me/i })).toBeInTheDocument()
   })
+
+  it('defaults type to button', () => {
+    render(<Button>Click</Button>)
+    const btn = screen.getByRole('button', { name: /click/i })
+    expect(btn).toHaveAttribute('type', 'button')
+  })
 })


### PR DESCRIPTION
## Summary
- Default Button to `type="button"` unless another type is provided
- Add unit test ensuring default button type

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689a6fccc9208322851f187d28597dce