### PR TITLE
fix intake schema

### DIFF
--- a/lib/model-schema.ts
+++ b/lib/model-schema.ts
@@ -14,7 +14,7 @@ const FollowupZ = z.object({
   field_id: z.string().min(1),
   ask: z.string().min(1),
   input_type: InputTypeZ,
-  choices: z.array(z.string()).min(1).optional(),
+  choices: z.array(z.string()).min(1).nullable().optional(),
   conditions: z.array(ShowIfCondZ).default([]),
 }).strict();
 
@@ -22,17 +22,18 @@ export const IntakeTurnZ = z.object({
   field_id: z.string().min(1),
   next_question: z.string().min(1),
   input_type: InputTypeZ,
-  choices: z.array(z.string()).min(1).optional(),
-  explain_why: z.string().optional(),
-  followups: z.array(FollowupZ).optional(),
+  choices: z.array(z.string()).min(1).nullable().optional(),
+  explain_why: z.string().nullable().optional(),
+  followups: z.array(FollowupZ).nullable().optional(),
   validation: z
     .object({
-      required: z.boolean().optional(),
-      min: z.number().optional(),
-      max: z.number().optional(),
-      pattern: z.string().optional(),
+      required: z.boolean().nullable().optional(),
+      min: z.number().nullable().optional(),
+      max: z.number().nullable().optional(),
+      pattern: z.string().nullable().optional(),
     })
     .strict()
+    .nullable()
     .optional(),
 }).strict();
 
@@ -48,10 +49,10 @@ export const IntakeTurnJSONSchema = {
       field_id: { type: "string" },
       next_question: { type: "string" },
       input_type: { type: "string", enum: ["singleSelect","multiSelect","slider","upload","yesNo","text"] },
-      choices: { type: "array", items: { type: "string" } },
-      explain_why: { type: "string" },
+      choices: { type: ["array","null"], items: { type: "string" } },
+      explain_why: { type: ["string","null"] },
       followups: {
-        type: "array",
+        type: ["array","null"],
         items: {
           type: "object",
           additionalProperties: false,
@@ -59,7 +60,7 @@ export const IntakeTurnJSONSchema = {
             field_id: { type: "string" },
             ask: { type: "string" },
             input_type: { type: "string", enum: ["singleSelect","multiSelect","slider","upload","yesNo","text"] },
-            choices: { type: "array", items: { type: "string" } },
+            choices: { type: ["array","null"], items: { type: "string" } },
             conditions: {
               type: "array",
               items: {
@@ -76,21 +77,22 @@ export const IntakeTurnJSONSchema = {
               }
             }
           },
-          required: ["field_id","ask","input_type","conditions"]
+          required: ["field_id","ask","input_type","choices","conditions"]
         }
       },
       validation: {
-        type: "object",
+        type: ["object","null"],
         additionalProperties: false,
         properties: {
-          required: { type: "boolean" },
-          min: { type: "number" },
-          max: { type: "number" },
-          pattern: { type: "string" },
-        }
+          required: { type: ["boolean","null"] },
+          min: { type: ["number","null"] },
+          max: { type: ["number","null"] },
+          pattern: { type: ["string","null"] },
+        },
+        required: ["required","min","max","pattern"]
       }
     },
-    required: ["field_id","next_question","input_type"]
+    required: ["field_id","next_question","input_type","choices","explain_why","followups","validation"]
   },
   strict: true,
 } as const;

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -11,14 +11,14 @@ export type Op = "==" | "!=" | ">=" | "<=" | ">" | "<" | "truthy" | "falsy";
 export interface ShowIfCond {
   field: string;
   op: Op;
-  value?: unknown;
+  value: unknown;
 }
 
 export interface Followup {
   field_id: string;
   ask: string;
   input_type: InputType;
-  choices?: string[];
+  choices?: string[] | null;
   conditions: ShowIfCond[]; // all must pass
 }
 
@@ -26,15 +26,15 @@ export interface IntakeTurn {
   field_id: string; // where the user's next answer should be saved
   next_question: string;
   input_type: InputType;
-  choices?: string[];
-  explain_why?: string;
-  followups?: Followup[];
+  choices?: string[] | null;
+  explain_why?: string | null;
+  followups?: Followup[] | null;
   validation?: {
-    required?: boolean;
-    min?: number;
-    max?: number;
-    pattern?: string;
-  };
+    required?: boolean | null;
+    min?: number | null;
+    max?: number | null;
+    pattern?: string | null;
+  } | null;
 }
 
 export type RoomType =


### PR DESCRIPTION
## Summary
- ensure intake JSON schema lists all properties as required and allows nullable optional fields
- update TypeScript interfaces to allow `null` values from responses API

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689ab8fc178483228d864b872f4dcb8d