### PR TITLE
feat: peach Siri-style glow frame

### DIFF
--- a/components/assistant/GlowFrame.tsx
+++ b/components/assistant/GlowFrame.tsx
@@ -1,32 +1,35 @@
 "use client";
 import React from "react";
 
-/** Shows a subtle animated edge glow when `active` is true. */
+/** Shows a peach Siri-style edge glow when `active` is true. */
 export default function GlowFrame({ active }: { active: boolean }) {
   if (!active) return null;
+
+  const peach = "#f2b897"; // CTA peach from home page
+
   return (
     <>
       <div className="pointer-events-none fixed inset-0 z-40">
-        <div className="absolute inset-2 rounded-[24px]">
-          <div
-            className="absolute inset-0 rounded-[24px] opacity-70"
-            style={{
-              background:
-                "conic-gradient(from 0deg at 50% 50%, #8be0c1, #c9f0dd, #a3c4ff, #e3d7ff, #8be0c1)",
-              filter: "blur(18px)",
-              animation: "colrvia-spin 7s linear infinite",
-              WebkitMask:
-                "radial-gradient(closest-side, rgba(0,0,0,0) 97%, rgba(0,0,0,1) 98%)",
-              mask:
-                "radial-gradient(closest-side, rgba(0,0,0,0) 97%, rgba(0,0,0,1) 98%)",
-            }}
-          />
-        </div>
+        <div className="absolute inset-2 rounded-[24px] border-2 glow-frame-peach" />
       </div>
       <style jsx global>{`
-        @keyframes colrvia-spin {
-          to {
-            transform: rotate(360deg);
+        .glow-frame-peach {
+          border-color: ${peach};
+          box-shadow:
+            0 0 40px rgba(242, 184, 151, 0.45),
+            inset 0 0 20px rgba(242, 184, 151, 0.35);
+          animation: glowPeachPulse 2.5s ease-in-out infinite;
+        }
+        @keyframes glowPeachPulse {
+          0%, 100% {
+            box-shadow:
+              0 0 40px rgba(242, 184, 151, 0.45),
+              inset 0 0 20px rgba(242, 184, 151, 0.35);
+          }
+          50% {
+            box-shadow:
+              0 0 80px rgba(242, 184, 151, 0.8),
+              inset 0 0 40px rgba(242, 184, 151, 0.6);
           }
         }
       `}</style>


### PR DESCRIPTION
## Summary
- Replace rainbow spinning glow with Siri-style rectangular edge glow in CTA peach
- Pulse animation uses `#f2b897` and removes oval cutout

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689ad54729d4832297c07d6f5748d882