### PR TITLE
feat: add typed analytics events

### DIFF
--- a/components/reveal/Cinematic.tsx
+++ b/components/reveal/Cinematic.tsx
@@ -27,7 +27,7 @@ export default function Cinematic({ open, onExit, story }: CinematicProps){
     } }
     window.addEventListener('keydown', key); return ()=>window.removeEventListener('keydown', key)
   },[open])
-  function end(){ track('cinematic_exit',{ id:story.id, seconds:elapsed.toFixed(1) }); onExit() }
+  function end(){ track('cinematic_exit',{ id:story.id, seconds:Number(elapsed.toFixed(1)) }); onExit() }
   const palette = story.palette || []
   const reduce = useReducedMotion()
   return <AnimatePresence>{open && (

--- a/lib/analytics.ts
+++ b/lib/analytics.ts
@@ -1,4 +1,6 @@
 import type { PostHog } from 'posthog-js'
+import type { AnalyticsEventName, AnalyticsEventPayload } from './analytics/events'
+
 let client: PostHog | null = null
 
 export function initAnalytics(){
@@ -15,7 +17,7 @@ export function initAnalytics(){
   return client
 }
 
-export function track(name: string, props?: Record<string,any>){
+export function track<E extends AnalyticsEventName>(name: E, props: AnalyticsEventPayload<E>){
   if(!client) return
   client.capture(name, props)
 }

--- a/lib/analytics/client.ts
+++ b/lib/analytics/client.ts
@@ -1,9 +1,10 @@
 // lib/analytics/client.ts
 "use client"
 import type { PostHog } from "posthog-js"
+import type { AnalyticsEventName, AnalyticsEventPayload } from "./events"
 
 let ready = false
-let q: Array<[string, Record<string, any> | undefined]> = []
+let q: Array<[AnalyticsEventName, any]> = []
 let ph: PostHog | null = null
 
 const KEY = process.env.NEXT_PUBLIC_POSTHOG_KEY
@@ -29,7 +30,7 @@ export function init() {
   }).catch(() => {})
 }
 
-export function track(name: string, props?: Record<string, any>) {
+export function track<E extends AnalyticsEventName>(name: E, props: AnalyticsEventPayload<E>) {
   if (!KEY) return // feature-flag off
   if (!ready) {
     q.push([name, props])

--- a/lib/analytics/events.ts
+++ b/lib/analytics/events.ts
@@ -1,0 +1,20 @@
+export interface AnalyticsEventMap {
+  nav_click: { dest: string }
+  designer_select: { designerId: string }
+  start_portal_open: { href: string; skipped?: boolean }
+  start_portal_nav: { href: string; ms: number }
+  howitworks_open: { where: string }
+  howitworks_modal_open: { origin: string }
+  howitworks_modal_close: { origin: string; action: string; ms: number }
+  howitworks_start: { where: 'modal' | 'page'; origin?: string; ms?: number }
+  share_image_download: { id: string; variant: string }
+  cinematic_play: { id: string }
+  cinematic_exit: { id: string; seconds: number }
+  explanation_view: { from: string; hasText: boolean }
+  explanation_copy: { len: number }
+  explanation_listen: { len: number }
+  variant_open: { id: string; variant: string }
+}
+
+export type AnalyticsEventName = keyof AnalyticsEventMap
+export type AnalyticsEventPayload<E extends AnalyticsEventName> = AnalyticsEventMap[E]

--- a/lib/analytics/index.ts
+++ b/lib/analytics/index.ts
@@ -1,13 +1,15 @@
 // lib/analytics/index.ts
 // SSR-safe shim; dynamically loads client in browser
-let _track = (_: string, __?: Record<string, any>) => {}
+import type { AnalyticsEventName, AnalyticsEventPayload } from "./events"
+
+let _track = <E extends AnalyticsEventName>(_name: E, _props: AnalyticsEventPayload<E>) => {}
 if (typeof window !== "undefined") {
   import("./client").then(m => {
     _track = m.track
     m.init?.()
   }).catch(()=>{})
 }
-export function track(name: string, props?: Record<string, any>) {
+export function track<E extends AnalyticsEventName>(name: E, props: AnalyticsEventPayload<E>) {
   try { _track(name, props) } catch { /* noop */ }
 }
 // Backwards compatibility for legacy imports

--- a/tests/lib/analytics.test.ts
+++ b/tests/lib/analytics.test.ts
@@ -3,6 +3,6 @@ import { describe, it, expect } from 'vitest'
 describe('analytics shim', () => {
   it('track() no-ops server side', async () => {
     const mod = await import('@/lib/analytics')
-    expect(() => mod.track('test_event',{ foo: 'bar' })).not.toThrow()
+    expect(() => mod.track('nav_click',{ dest: '/test' })).not.toThrow()
   })
 })

--- a/tests/lib/analytics.types.test.ts
+++ b/tests/lib/analytics.types.test.ts
@@ -1,0 +1,12 @@
+import { track } from '@/lib/analytics'
+
+describe('analytics event typing', () => {
+  it('accepts defined events', () => {
+    track('nav_click', { dest: '/home' })
+  })
+
+  // @ts-expect-error - invalid event name
+  track('invalid_event', {})
+  // @ts-expect-error - invalid payload
+  track('nav_click', { wrong: true })
+})


### PR DESCRIPTION
## Summary
- define union mapping of analytics events and payloads
- type `track` helper to enforce event names and properties
- add tests verifying analytics event typings

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689ada9e894c832288f8f3a689e068e6