### PR TITLE
feat(pwa): cache reveal pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Colrvia
 
 ## PWA
-Manifest route at `/manifest.webmanifest` (Next auto). Service worker in `public/sw.js` precaches `/` and `/offline` and provides network-first navigation with offline fallback. Install prompt banner component `components/pwa/InstallPrompt.tsx` (render on app pages). Icons under `public/icons` (supply real PNGs 192/512 + maskable variants). Update theme/background colors in `app/manifest.ts` if brand evolves.
+Manifest route at `/manifest.webmanifest` (Next auto). Service worker in `public/sw.js` precaches `/` and `/offline`, caches `/reveal/*` shells and related `/api/stories/*` + `/api/share/*/image` responses with stale‑while‑revalidate, and serves cached reveal pages when offline (falling back to `/offline`). Install prompt banner component `components/pwa/InstallPrompt.tsx` (render on app pages). Icons under `public/icons` (supply real PNGs 192/512 + maskable variants). Update theme/background colors in `app/manifest.ts` if brand evolves.
 
 Testing offline:
 1. Build & run locally.

--- a/public/sw.js
+++ b/public/sw.js
@@ -1,16 +1,44 @@
-const VERSION='v1';
+const VERSION='v2';
 const CORE_URLS=['/','/offline'];
 self.addEventListener('install',e=>{e.waitUntil(caches.open(VERSION).then(c=>c.addAll(CORE_URLS)).then(()=>self.skipWaiting()))});
 self.addEventListener('activate',e=>{e.waitUntil(caches.keys().then(keys=>Promise.all(keys.filter(k=>k!==VERSION).map(k=>caches.delete(k)))).then(()=>self.clients.claim()))});
 
-function isStatic(req){return req.url.includes('/_next/static/')|| req.url.includes('/icons/')} 
+function isStatic(req){return req.url.includes('/_next/static/')||req.url.includes('/icons/')}
+function isReveal(req){return req.url.includes('/reveal/')}
+function isStory(req){return req.url.includes('/api/stories/')}
+function isPaletteImg(req){return req.url.includes('/api/share/')&&req.destination==='image'}
+
 self.addEventListener('fetch',event=>{
   const req=event.request;
   if(req.mode==='navigate'){
-    event.respondWith((async()=>{try{const net=await fetch(req); const cache=await caches.open(VERSION); cache.put(req,net.clone()); return net;}catch(e){const cache=await caches.open(VERSION); const offline=await cache.match('/offline'); return offline || Response.error();}})());
+    event.respondWith((async()=>{
+      const cache=await caches.open(VERSION);
+      try{
+        const net=await fetch(req);
+        if(isReveal(req)) cache.put(req,net.clone());
+        return net;
+      }catch(e){
+        if(isReveal(req)){
+          const cached=await cache.match(req);
+          if(cached) return cached;
+        }
+        const offline=await cache.match('/offline');
+        return offline||Response.error();
+      }
+    })());
     return;
   }
   if(isStatic(req)){
-    event.respondWith(caches.match(req).then(cached=>cached||fetch(req).then(res=>{const copy=res.clone(); caches.open(VERSION).then(c=>c.put(req,copy)); return res;})));
+    event.respondWith(caches.match(req).then(cached=>cached||fetch(req).then(res=>{caches.open(VERSION).then(c=>c.put(req,res.clone()));return res;})));
+    return;
+  }
+  if(isStory(req)||isPaletteImg(req)){
+    event.respondWith((async()=>{
+      const cache=await caches.open(VERSION);
+      const cached=await cache.match(req);
+      const fetchPromise=fetch(req).then(res=>{cache.put(req,res.clone());return res;}).catch(()=>cached);
+      if(cached){event.waitUntil(fetchPromise);return cached;}
+      return fetchPromise;
+    })());
   }
 });


### PR DESCRIPTION
## Summary
- cache `/reveal/*` shells and story/palette responses with stale-while-revalidate
- serve cached reveal pages when offline with `/offline` fallback
- document updated PWA caching strategy

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689add10f6508322b0e05d6aa9915d07