### PR TITLE
Use culori for ΔE2000 color difference

### DIFF
--- a/lib/ai/color.ts
+++ b/lib/ai/color.ts
@@ -1,6 +1,8 @@
-// Lightweight color utilities: hex->LAB, deltaE (CIE76), contrast ratio, ensureContrast, undertone signal
+// Lightweight color utilities: hex->LAB, deltaE (ΔE2000), contrast ratio, ensureContrast, undertone signal
 
 export type LAB = { L: number; a: number; b: number }
+
+import { differenceCiede2000 } from 'culori'
 
 function hexToRgb(hex: string): { r: number; g: number; b: number } {
   const h = hex.replace('#','')
@@ -36,11 +38,17 @@ export function hexToLab(hex: string): LAB {
   return { L, a, b: b2 }
 }
 
+const de00 = differenceCiede2000()
+
 export function deltaE(l1: LAB, l2: LAB): number {
-  const dL = l1.L - l2.L
-  const da = l1.a - l2.a
-  const db = l1.b - l2.b
-  return Math.sqrt(dL*dL + da*da + db*db)
+  return de00(
+    { mode: 'lab65', l: l1.L, a: l1.a, b: l1.b },
+    { mode: 'lab65', l: l2.L, a: l2.a, b: l2.b }
+  )
+}
+
+export function deltaEHex(hex1: string, hex2: string): number {
+  return deltaE(hexToLab(hex1), hexToLab(hex2))
 }
 
 export function luminance(hex: string): number {

--- a/lib/ai/variants.ts
+++ b/lib/ai/variants.ts
@@ -1,5 +1,5 @@
 import { Swatch, Brand } from '@/types/story'
-import { contrastRatio, ensureContrast } from './color'
+import { contrastRatio, ensureContrast, deltaEHex } from './color'
 
 type Tweak = 'softer'|'bolder'
 
@@ -39,10 +39,10 @@ export function makeVariant(base: Swatch[], _brand: Brand, tweak: Tweak): Swatch
     else if (role==='trim' && trimHex) hex = trimHex
     else if (role==='accent') {
       hex = shift(hex, tweak==='softer'? 'softer':'bolder', 0.12)
-      // accent vs walls ≥2:1
+      // accent vs walls ≥2:1 and visibly different
       if (wallsHex) {
         let tries=0
-        while (contrastRatio(hex, wallsHex) < 2 && tries<10) {
+        while ((contrastRatio(hex, wallsHex) < 2 || deltaEHex(hex, wallsHex) < 10) && tries<10) {
           hex = shift(hex, tweak==='softer'? 'softer':'bolder', 0.06)
           tries++
         }

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,6 +17,7 @@
         "@supabase/supabase-js": "latest",
         "@vercel/analytics": "1.3.1",
         "clsx": "2.1.0",
+        "culori": "^4.0.2",
         "framer-motion": "10.16.0",
         "lucide-react": "^0.539.0",
         "next": "^14.2.31",
@@ -3845,6 +3846,15 @@
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
       "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==",
       "devOptional": true
+    },
+    "node_modules/culori": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/culori/-/culori-4.0.2.tgz",
+      "integrity": "sha512-1+BhOB8ahCn4O0cep0Sh2l9KCOfOdY+BXJnKMHFFzDEouSr/el18QwXEMRlOj9UY5nCeA8UN3a/82rUWRBeyBw==",
+      "license": "MIT",
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      }
     },
     "node_modules/damerau-levenshtein": {
       "version": "1.0.8",

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "@supabase/supabase-js": "latest",
     "@vercel/analytics": "1.3.1",
     "clsx": "2.1.0",
+    "culori": "^4.0.2",
     "framer-motion": "10.16.0",
     "lucide-react": "^0.539.0",
     "next": "^14.2.31",

--- a/tests/ai.test.ts
+++ b/tests/ai.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest'
-import { ensureContrast, contrastRatio } from '@/lib/ai/color'
+import { ensureContrast, contrastRatio, deltaEHex } from '@/lib/ai/color'
 import { makeVariant } from '@/lib/ai/variants'
 
 const sampleBase = [
@@ -15,6 +15,18 @@ describe('contrast helpers', () => {
   })
 })
 
+describe('deltaE', () => {
+  it('returns 0 for identical colors', () => {
+    expect(deltaEHex('#ffffff', '#ffffff')).toBeCloseTo(0, 5)
+  })
+  it('is symmetric and increases with difference', () => {
+    const near = deltaEHex('#000000', '#010101')
+    const far = deltaEHex('#000000', '#ffffff')
+    expect(deltaEHex('#000000', '#ffffff')).toBeCloseTo(deltaEHex('#ffffff', '#000000'), 5)
+    expect(far).toBeGreaterThan(near)
+  })
+})
+
 describe('variants', () => {
   it('softer accent is lighter than base accent', () => {
     const softer = makeVariant(sampleBase, 'SW', 'softer')
@@ -27,5 +39,11 @@ describe('variants', () => {
   const baseAccent = sampleBase.find((s: any)=>s.role==='accent')!.hex
   const boldAccent = bolder.find((s: any)=>s.role==='accent')!.hex
     expect(boldAccent).not.toBe(baseAccent)
+  })
+  it('accent maintains perceptible deltaE from walls', () => {
+    const softer = makeVariant(sampleBase, 'SW', 'softer')
+    const walls = softer.find((s: any)=>s.role==='walls')!.hex
+    const accent = softer.find((s: any)=>s.role==='accent')!.hex
+    expect(deltaEHex(accent, walls)).toBeGreaterThan(10)
   })
 })


### PR DESCRIPTION
## Summary
- add `culori` for color difference calculations
- replace manual deltaE with culori's ΔE2000
- ensure variants use deltaE for accent/wall contrast and add tests

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689ade69afcc83228a77c098b078d8da