### PR TITLE
feat: persist analytics events offline until reconnect

### DIFF
--- a/lib/analytics.ts
+++ b/lib/analytics.ts
@@ -2,6 +2,44 @@ import type { PostHog } from 'posthog-js'
 import type { AnalyticsEventName, AnalyticsEventPayload } from './analytics/events'
 
 let client: PostHog | null = null
+const QUEUE_KEY = 'ph_queue'
+
+type QueuedEvent = { name: AnalyticsEventName; props: any }
+
+function readQueue(): QueuedEvent[] {
+  if (typeof window === 'undefined') return []
+  try {
+    const raw = localStorage.getItem(QUEUE_KEY)
+    return raw ? JSON.parse(raw) as QueuedEvent[] : []
+  } catch {
+    return []
+  }
+}
+
+function writeQueue(q: QueuedEvent[]) {
+  if (typeof window === 'undefined') return
+  try {
+    if (q.length) localStorage.setItem(QUEUE_KEY, JSON.stringify(q))
+    else localStorage.removeItem(QUEUE_KEY)
+  } catch {
+    /* noop */
+  }
+}
+
+function enqueue<E extends AnalyticsEventName>(name: E, props: AnalyticsEventPayload<E>) {
+  const q = readQueue()
+  q.push({ name, props })
+  writeQueue(q)
+}
+
+function flushQueue() {
+  if (!client || typeof window === 'undefined' || !navigator.onLine) return
+  const q = readQueue()
+  q.forEach(evt => {
+    try { client!.capture(evt.name, evt.props) } catch { /* noop */ }
+  })
+  writeQueue([])
+}
 
 export function initAnalytics(){
   if(typeof window === 'undefined') return
@@ -13,12 +51,22 @@ export function initAnalytics(){
   import('posthog-js').then(m=>{
     m.default.init(key, { api_host: host, capture_pageview: false })
     client = m.default
+    flushQueue()
+  })
+  window.addEventListener('online', flushQueue)
+  navigator.serviceWorker?.addEventListener('message', e => {
+    if (e.data === 'online') flushQueue()
   })
   return client
 }
 
 export function track<E extends AnalyticsEventName>(name: E, props: AnalyticsEventPayload<E>){
-  if(!client) return
+  if(typeof window === 'undefined') return
+  if(!client || !navigator.onLine){
+    enqueue(name, props)
+    initAnalytics()
+    return
+  }
   client.capture(name, props)
 }
 export function identify(id:string, email?:string){ if(!client) return; client.identify(id, email? { email }: undefined)}

--- a/public/sw.js
+++ b/public/sw.js
@@ -42,3 +42,10 @@ self.addEventListener('fetch',event=>{
     })());
   }
 });
+
+self.addEventListener('online',()=>{
+  self.clients.matchAll().then(clients=>clients.forEach(c=>c.postMessage('online')))
+});
+self.addEventListener('offline',()=>{
+  self.clients.matchAll().then(clients=>clients.forEach(c=>c.postMessage('offline')))
+});

--- a/tests/lib/analytics.offline.test.ts
+++ b/tests/lib/analytics.offline.test.ts
@@ -1,0 +1,39 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+vi.mock('posthog-js', () => {
+  return {
+    default: {
+      init: vi.fn(),
+      capture: vi.fn(),
+      identify: vi.fn(),
+      register: vi.fn(),
+    }
+  }
+})
+
+describe('analytics offline queue', () => {
+  beforeEach(() => {
+    vi.resetModules()
+    vi.clearAllMocks()
+    localStorage.clear()
+    process.env.NEXT_PUBLIC_POSTHOG_KEY = 'test'
+  })
+
+  it('queues events offline and flushes when back online', async () => {
+    const onlineSpy = vi.spyOn(navigator, 'onLine', 'get').mockReturnValue(false)
+    const analytics = await import('@/lib/analytics')
+    analytics.track('nav_click', { dest: '/foo' })
+    expect(JSON.parse(localStorage.getItem('ph_queue') || '[]')).toHaveLength(1)
+
+    await new Promise(r => setTimeout(r))
+    const posthog = (await import('posthog-js')).default as any
+    expect(posthog.capture).not.toHaveBeenCalled()
+
+    onlineSpy.mockReturnValue(true)
+    window.dispatchEvent(new Event('online'))
+
+    expect(posthog.capture).toHaveBeenCalledWith('nav_click', { dest: '/foo' })
+    expect(localStorage.getItem('ph_queue')).toBeNull()
+    onlineSpy.mockRestore()
+  })
+})


### PR DESCRIPTION
## Summary
- queue analytics events in localStorage when offline
- send queued events once PostHog is ready and network resumes
- service worker posts online/offline status to clients
- add unit test covering offline queue flush

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689ae06ce57c8322a5536f147b2c4bc2