### PR TITLE
Use Radix dialog for Cinematic focus trap

### DIFF
--- a/__tests__/cinematic.a11y.test.tsx
+++ b/__tests__/cinematic.a11y.test.tsx
@@ -1,0 +1,50 @@
+import React from 'react'
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { vi } from 'vitest'
+import Cinematic from '@/components/reveal/Cinematic'
+import { MotionProvider } from '@/components/theme/MotionSettings'
+
+const story = {
+  id: '1',
+  title: 'Story',
+  palette: [{ hex: '#fff', role: 'base' }],
+  narrative: 'First line.',
+  placements: {}
+}
+
+test('cinematic traps focus and closes on escape', async () => {
+  const user = userEvent.setup()
+  const onExit = vi.fn()
+  Object.defineProperty(window, 'matchMedia', {
+    writable: true,
+    value: () => ({
+      matches: false,
+      media: '',
+      onchange: null,
+      addEventListener: () => {},
+      removeEventListener: () => {},
+      addListener: () => {},
+      removeListener: () => {},
+      dispatchEvent: () => false,
+    }),
+  })
+  render(
+    <MotionProvider>
+      <button data-testid="outside">outside</button>
+      <Cinematic open story={story} onExit={onExit} />
+    </MotionProvider>
+  )
+
+  const exit = screen.getByRole('button', { name: /exit reveal/i })
+  expect(exit).toHaveFocus()
+
+  await user.tab()
+  expect(exit).toHaveFocus()
+
+  await user.tab({ shift: true })
+  expect(exit).toHaveFocus()
+
+  await user.keyboard('{Escape}')
+  expect(onExit).toHaveBeenCalled()
+})

--- a/components/reveal/Cinematic.tsx
+++ b/components/reveal/Cinematic.tsx
@@ -1,6 +1,7 @@
 "use client"
 import React, { useEffect, useRef, useState } from 'react'
 import { motion, AnimatePresence } from 'framer-motion'
+import * as Dialog from '@radix-ui/react-dialog'
 import { useReducedMotion } from '@/components/theme/MotionSettings'
 import { track, initAnalytics } from '@/lib/analytics'
 
@@ -14,26 +15,22 @@ export default function Cinematic({ open, onExit, story }: CinematicProps){
     const t = setInterval(()=>{ if(startRef.current) setElapsed((performance.now()-startRef.current)/1000) },500)
     return ()=>clearInterval(t)
   },[open, story.id])
-  // Focus trap & esc handling
-  const containerRef = useRef<HTMLDivElement | null>(null)
-  useEffect(()=>{
-    function key(e:KeyboardEvent){ if(e.key==='Escape' && open){ end() } if(e.key==='Tab' && open && containerRef.current){
-      const focusables = containerRef.current.querySelectorAll<HTMLElement>('button, [href], [tabindex]:not([tabindex="-1"])')
-      if(focusables.length===0) return
-      const first = focusables[0]
-      const last = focusables[focusables.length-1]
-      if(e.shiftKey && document.activeElement===first){ e.preventDefault(); last.focus() }
-      else if(!e.shiftKey && document.activeElement===last){ e.preventDefault(); first.focus() }
-    } }
-    window.addEventListener('keydown', key); return ()=>window.removeEventListener('keydown', key)
-  },[open])
   function end(){ track('cinematic_exit',{ id:story.id, seconds:Number(elapsed.toFixed(1)) }); onExit() }
   const palette = story.palette || []
   const reduce = useReducedMotion()
-  return <AnimatePresence>{open && (
-    <motion.div initial={{opacity:0}} animate={{opacity:1}} exit={{opacity:0}} className="fixed inset-0 z-[100] bg-neutral-900 text-neutral-50">
-      <div className="absolute inset-0 pointer-events-none bg-[radial-gradient(circle_at_center,transparent,rgba(0,0,0,0.6))]" />
-      <div ref={containerRef} className="relative h-full flex flex-col p-8 md:p-16 gap-12 overflow-hidden" role="dialog" aria-modal="true" aria-label="Palette reveal cinematic">
+  return (
+    <Dialog.Root open={open} onOpenChange={(o) => { if (!o) end() }}>
+      <Dialog.Portal forceMount>
+        <AnimatePresence>
+          {open && (
+            <motion.div initial={{opacity:0}} animate={{opacity:1}} exit={{opacity:0}} className="fixed inset-0 z-[100] bg-neutral-900 text-neutral-50">
+              <div className="absolute inset-0 pointer-events-none bg-[radial-gradient(circle_at_center,transparent,rgba(0,0,0,0.6))]" />
+              <Dialog.Content
+                className="relative h-full flex flex-col p-8 md:p-16 gap-12 overflow-hidden"
+                role="dialog"
+                aria-modal="true"
+                aria-label="Palette reveal cinematic"
+              >
   <motion.h1 initial={reduce?undefined:{opacity:0, y:20}} animate={reduce?undefined:{opacity:1, y:0}} transition={{duration: reduce?0:.6, ease:'easeOut'}} className="text-4xl md:text-6xl font-semibold tracking-tight max-w-3xl leading-tight">{story.title}</motion.h1>
         <motion.div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-5 gap-6 flex-1 items-start content-start"
           initial={reduce?undefined:"hidden"} animate={reduce?undefined:"show"} variants={reduce?undefined:{ hidden:{}, show:{ transition:{ staggerChildren:.12 } } }}>
@@ -50,7 +47,11 @@ export default function Cinematic({ open, onExit, story }: CinematicProps){
         <div className="flex gap-4 pt-4">
           <button autoFocus onClick={end} className="px-5 py-2 rounded-full bg-white text-neutral-900 text-sm font-medium hover:bg-neutral-200 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-white active:scale-[.97] transition-transform">Exit reveal (Esc)</button>
         </div>
-      </div>
-    </motion.div>
-  )}</AnimatePresence>
+              </Dialog.Content>
+            </motion.div>
+          )}
+        </AnimatePresence>
+      </Dialog.Portal>
+    </Dialog.Root>
+  )
 }


### PR DESCRIPTION
## Summary
- replace custom focus management in Cinematic with Radix Dialog
- ensure dialog exposes appropriate ARIA roles
- add accessibility test verifying focus trap and escape behavior

## Testing
- `npm test __tests__/cinematic.a11y.test.tsx`

------
https://chatgpt.com/codex/tasks/task_e_689ae2a052d88322b3bb2cf391c5cb22