### PR TITLE
feat: add i18n support

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -2,6 +2,7 @@
 import React from 'react'
 import Link from "next/link"
 import { motion } from "framer-motion"
+import { useTranslations } from 'next-intl'
 import nextDynamic from "next/dynamic"
 import { useState } from "react"
 const HowItWorksModal = nextDynamic(() => import("@/components/marketing/HowItWorksModal"), { ssr: false })
@@ -13,6 +14,7 @@ export default function HomePage() {
   // @ts-ignore client boundary ok
   const [open, setOpen] = useState(false)
   const startStory = useStartStory()
+  const t = useTranslations('HomePage')
   return (
     <main className="relative mx-auto max-w-3xl px-4 py-12 bg-[#404934] text-[#F7F7F2]">
       <div className="absolute inset-0 pointer-events-none" aria-hidden>
@@ -22,16 +24,16 @@ export default function HomePage() {
       <div className="relative space-y-10">
         <header className="space-y-6">
           <div className="space-y-2">
-            <p className="text-sm uppercase tracking-wide text-[#d1d9ce]">instant color confidence</p>
+            <p className="text-sm uppercase tracking-wide text-[#d1d9ce]">{t('tagline')}</p>
             <motion.h1
               initial={{ opacity: 0, y: 20 }}
               animate={{ opacity: 1, y: 0 }}
               transition={{ delay: 0.05 }}
               className="font-display text-4xl sm:text-5xl leading-[1.05] font-semibold"
             >
-              from vibe to walls in minutes.
+              {t('headline')}
               <br />
-              <span className="text-[#f2b897]">real paint codes. clear placements.</span>
+              <span className="text-[#f2b897]">{t('highlight')}</span>
             </motion.h1>
           </div>
           <div className="flex flex-wrap gap-4">
@@ -39,7 +41,7 @@ export default function HomePage() {
               type="button"
               onClick={() => setOpen(true)}
               className="px-5 py-2 rounded-full border border-[#566049] text-sm hover:bg-[#566049]/30 transition"
-            >How it works</button>
+            >{t('howItWorks')}</button>
           </div>
         </header>
         <div className="mt-8">
@@ -49,7 +51,7 @@ export default function HomePage() {
             className="inline-flex items-center justify-center rounded-2xl px-8 py-4 text-xl md:text-2xl font-semibold w-full sm:w-auto hover:opacity-95"
             style={{ backgroundColor: "#f2b897", color: "#1f2937" }}
           >
-            Start Color Story
+            {t('start')}
           </Link>
         </div>
       </div>

--- a/docs/TRANSLATION.md
+++ b/docs/TRANSLATION.md
@@ -1,0 +1,20 @@
+# Translation Workflow
+
+This project uses [`next-intl`](https://next-intl.dev/) for internationalization.
+
+## Adding or updating translations
+
+1. Edit `messages/en.json` with any new keys.
+2. Copy the same keys into other locale files such as `messages/es.json` and translate the values.
+3. If adding a new locale, create a new JSON file in `messages/` (e.g. `fr.json`) and add the locale code to `locales` in [`lib/i18n.ts`](../lib/i18n.ts).
+4. Run the development server to verify your translations:
+
+```bash
+npm run dev
+```
+
+The application detects the visitor's preferred language via the `Accept-Language` header and loads the appropriate messages at runtime.
+
+## Example
+
+Spanish translations live in [`messages/es.json`](../messages/es.json). Update these files when translators deliver new strings.

--- a/lib/i18n.ts
+++ b/lib/i18n.ts
@@ -1,0 +1,29 @@
+import { headers } from 'next/headers'
+
+export const locales = ['en', 'es'] as const
+export type Locale = (typeof locales)[number]
+export const defaultLocale: Locale = 'en'
+
+export function getLocale(): Locale {
+  try {
+    const header = headers().get('accept-language')
+    if (header) {
+      const languages = header.split(',').map(part => part.split(';')[0].trim())
+      for (const lang of languages) {
+        const base = lang.toLowerCase().split('-')[0]
+        if (locales.includes(base as Locale)) return base as Locale
+      }
+    }
+  } catch {
+    // headers() not available (e.g., during tests)
+  }
+  return defaultLocale
+}
+
+export async function getMessages(locale: Locale) {
+  try {
+    return (await import(`../messages/${locale}.json`)).default
+  } catch {
+    return (await import(`../messages/${defaultLocale}.json`)).default
+  }
+}

--- a/messages/en.json
+++ b/messages/en.json
@@ -1,0 +1,51 @@
+{
+  "Layout": {"skipToContent": "Skip to content"},
+  "HomePage": {
+    "tagline": "instant color confidence",
+    "headline": "from vibe to walls in minutes.",
+    "highlight": "real paint codes. clear placements.",
+    "howItWorks": "How it works",
+    "start": "Start Color Story"
+  },
+  "SignInPage": {
+    "brand": "COLRVIA",
+    "titleSignIn": "Sign in",
+    "titleCreate": "Create account",
+    "magicLinkTab": "Magic link",
+    "passwordTab": "Email & password",
+    "emailPlaceholder": "you@example.com",
+    "sendMagicLinkIdle": "Send magic link",
+    "sendMagicLinkBusy": "Sending…",
+    "passwordPlaceholder": "Password",
+    "passwordMinPlaceholder": "Password (min 6 chars)",
+    "confirmPasswordPlaceholder": "Confirm password",
+    "signInSubmitIdle": "Sign in",
+    "signInSubmitBusy": "Signing in…",
+    "createAccountSubmitIdle": "Create account",
+    "createAccountSubmitBusy": "Creating…",
+    "needAccount": "Need an account? Create one",
+    "haveAccount": "Have an account? Sign in",
+    "didntGetEmail": "Didn’t get the email?",
+    "resendConfirmation": "Resend confirmation",
+    "addSiteUrl": "Add this site URL to your Supabase Auth Redirect URLs if emails fail.",
+    "or": "OR",
+    "continueWithGoogle": "Continue with Google",
+    "backToHome": "Back to home",
+    "redirectOrigin": "Redirect origin: {origin}",
+    "messages": {
+      "enterEmail": "Please enter an email",
+      "checkEmailMagicLink": "Check your email for the magic link.",
+      "couldNotSendMagicLink": "Could not send magic link",
+      "googleSignInFailed": "Google sign-in failed",
+      "emailPasswordRequired": "Email and password required",
+      "signedInRedirecting": "Signed in, redirecting…",
+      "signInFailed": "Sign in failed",
+      "passwordMin": "Password must be at least 6 characters",
+      "passwordsNoMatch": "Passwords do not match",
+      "checkEmailConfirm": "Check your email to confirm your address. If it does not arrive within a minute, check spam or click Resend below.",
+      "signUpFailed": "Sign up failed",
+      "confirmationResent": "Confirmation email resent. Check inbox & spam.",
+      "couldNotResend": "Could not resend confirmation email"
+    }
+  }
+}

--- a/messages/es.json
+++ b/messages/es.json
@@ -1,0 +1,51 @@
+{
+  "Layout": {"skipToContent": "Saltar al contenido"},
+  "HomePage": {
+    "tagline": "confianza instantánea en el color",
+    "headline": "de la vibra a las paredes en minutos.",
+    "highlight": "códigos de pintura reales. ubicaciones claras.",
+    "howItWorks": "Cómo funciona",
+    "start": "Comenzar historia de color"
+  },
+  "SignInPage": {
+    "brand": "COLRVIA",
+    "titleSignIn": "Iniciar sesión",
+    "titleCreate": "Crear cuenta",
+    "magicLinkTab": "Enlace mágico",
+    "passwordTab": "Correo y contraseña",
+    "emailPlaceholder": "tu@ejemplo.com",
+    "sendMagicLinkIdle": "Enviar enlace mágico",
+    "sendMagicLinkBusy": "Enviando…",
+    "passwordPlaceholder": "Contraseña",
+    "passwordMinPlaceholder": "Contraseña (mín 6 caracteres)",
+    "confirmPasswordPlaceholder": "Confirmar contraseña",
+    "signInSubmitIdle": "Iniciar sesión",
+    "signInSubmitBusy": "Iniciando sesión…",
+    "createAccountSubmitIdle": "Crear cuenta",
+    "createAccountSubmitBusy": "Creando…",
+    "needAccount": "¿Necesitas una cuenta? Crea una",
+    "haveAccount": "¿Tienes una cuenta? Inicia sesión",
+    "didntGetEmail": "¿No recibiste el correo?",
+    "resendConfirmation": "Reenviar confirmación",
+    "addSiteUrl": "Agrega esta URL del sitio a tus URLs de redirección de Supabase Auth si los correos fallan.",
+    "or": "O",
+    "continueWithGoogle": "Continuar con Google",
+    "backToHome": "Volver al inicio",
+    "redirectOrigin": "Origen de redirección: {origin}",
+    "messages": {
+      "enterEmail": "Por favor ingresa un correo",
+      "checkEmailMagicLink": "Revisa tu correo para el enlace mágico.",
+      "couldNotSendMagicLink": "No se pudo enviar el enlace mágico",
+      "googleSignInFailed": "Error al iniciar sesión con Google",
+      "emailPasswordRequired": "Se requieren correo y contraseña",
+      "signedInRedirecting": "Sesión iniciada, redirigiendo…",
+      "signInFailed": "Error al iniciar sesión",
+      "passwordMin": "La contraseña debe tener al menos 6 caracteres",
+      "passwordsNoMatch": "Las contraseñas no coinciden",
+      "checkEmailConfirm": "Revisa tu correo para confirmar tu dirección. Si no llega en un minuto, revisa el spam o haz clic en Reenviar abajo.",
+      "signUpFailed": "Error al registrarse",
+      "confirmationResent": "Correo de confirmación reenviado. Revisa bandeja y spam.",
+      "couldNotResend": "No se pudo reenviar el correo de confirmación"
+    }
+  }
+}

--- a/next.config.js
+++ b/next.config.js
@@ -1,5 +1,6 @@
 /** @type {import('next').NextConfig} */
 const nextConfig = {
+  i18n: { locales: ['en', 'es'], defaultLocale: 'en' },
   reactStrictMode: true,
   async redirects() {
     return [

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,6 +21,7 @@
         "framer-motion": "10.16.0",
         "lucide-react": "^0.539.0",
         "next": "^14.2.31",
+        "next-intl": "^4.3.4",
         "next-themes": "0.3.0",
         "openai": "^5.12.2",
         "posthog-js": "^1.178.1",
@@ -760,6 +761,66 @@
       "dev": true,
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      }
+    },
+    "node_modules/@formatjs/ecma402-abstract": {
+      "version": "2.3.4",
+      "resolved": "https://registry.npmjs.org/@formatjs/ecma402-abstract/-/ecma402-abstract-2.3.4.tgz",
+      "integrity": "sha512-qrycXDeaORzIqNhBOx0btnhpD1c+/qFIHAN9znofuMJX6QBwtbrmlpWfD4oiUUD2vJUOIYFA/gYtg2KAMGG7sA==",
+      "license": "MIT",
+      "dependencies": {
+        "@formatjs/fast-memoize": "2.2.7",
+        "@formatjs/intl-localematcher": "0.6.1",
+        "decimal.js": "^10.4.3",
+        "tslib": "^2.8.0"
+      }
+    },
+    "node_modules/@formatjs/ecma402-abstract/node_modules/@formatjs/intl-localematcher": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/@formatjs/intl-localematcher/-/intl-localematcher-0.6.1.tgz",
+      "integrity": "sha512-ePEgLgVCqi2BBFnTMWPfIghu6FkbZnnBVhO2sSxvLfrdFw7wCHAHiDoM2h4NRgjbaY7+B7HgOLZGkK187pZTZg==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.8.0"
+      }
+    },
+    "node_modules/@formatjs/fast-memoize": {
+      "version": "2.2.7",
+      "resolved": "https://registry.npmjs.org/@formatjs/fast-memoize/-/fast-memoize-2.2.7.tgz",
+      "integrity": "sha512-Yabmi9nSvyOMrlSeGGWDiH7rf3a7sIwplbvo/dlz9WCIjzIQAfy1RMf4S0X3yG724n5Ghu2GmEl5NJIV6O9sZQ==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.8.0"
+      }
+    },
+    "node_modules/@formatjs/icu-messageformat-parser": {
+      "version": "2.11.2",
+      "resolved": "https://registry.npmjs.org/@formatjs/icu-messageformat-parser/-/icu-messageformat-parser-2.11.2.tgz",
+      "integrity": "sha512-AfiMi5NOSo2TQImsYAg8UYddsNJ/vUEv/HaNqiFjnI3ZFfWihUtD5QtuX6kHl8+H+d3qvnE/3HZrfzgdWpsLNA==",
+      "license": "MIT",
+      "dependencies": {
+        "@formatjs/ecma402-abstract": "2.3.4",
+        "@formatjs/icu-skeleton-parser": "1.8.14",
+        "tslib": "^2.8.0"
+      }
+    },
+    "node_modules/@formatjs/icu-skeleton-parser": {
+      "version": "1.8.14",
+      "resolved": "https://registry.npmjs.org/@formatjs/icu-skeleton-parser/-/icu-skeleton-parser-1.8.14.tgz",
+      "integrity": "sha512-i4q4V4qslThK4Ig8SxyD76cp3+QJ3sAqr7f6q9VVfeGtxG9OhiAk3y9XF6Q41OymsKzsGQ6OQQoJNY4/lI8TcQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@formatjs/ecma402-abstract": "2.3.4",
+        "tslib": "^2.8.0"
+      }
+    },
+    "node_modules/@formatjs/intl-localematcher": {
+      "version": "0.5.10",
+      "resolved": "https://registry.npmjs.org/@formatjs/intl-localematcher/-/intl-localematcher-0.5.10.tgz",
+      "integrity": "sha512-af3qATX+m4Rnd9+wHcjJ4w2ijq+rAVP3CCinJQvFv1kgSu1W6jypUmvleJxcewdxmutM8dmIRZFxO/IQBZmP2Q==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "2"
       }
     },
     "node_modules/@hookform/resolvers": {
@@ -1969,6 +2030,12 @@
       "resolved": "https://registry.npmjs.org/@rushstack/eslint-patch/-/eslint-patch-1.12.0.tgz",
       "integrity": "sha512-5EwMtOqvJMMa3HbmxLlF74e+3/HhwBTMcvt3nqVJgGCozO6hzIPOBlwm8mGVNR9SN2IJpxSnlxczyDjcn7qIyw==",
       "dev": true
+    },
+    "node_modules/@schummar/icu-type-parser": {
+      "version": "1.21.5",
+      "resolved": "https://registry.npmjs.org/@schummar/icu-type-parser/-/icu-type-parser-1.21.5.tgz",
+      "integrity": "sha512-bXHSaW5jRTmke9Vd0h5P7BtWZG9Znqb8gSDxZnxaGSJnGwPLDPfS+3g0BKzeWqzgZPsIVZkM7m2tbo18cm5HBw==",
+      "license": "MIT"
     },
     "node_modules/@sinclair/typebox": {
       "version": "0.27.8",
@@ -3980,8 +4047,7 @@
     "node_modules/decimal.js": {
       "version": "10.6.0",
       "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
-      "integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
-      "dev": true
+      "integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg=="
     },
     "node_modules/deep-eql": {
       "version": "4.1.4",
@@ -5588,6 +5654,18 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/intl-messageformat": {
+      "version": "10.7.16",
+      "resolved": "https://registry.npmjs.org/intl-messageformat/-/intl-messageformat-10.7.16.tgz",
+      "integrity": "sha512-UmdmHUmp5CIKKjSoE10la5yfU+AYJAaiYLsodbjL4lji83JNvgOQUjGaGhGrpFCb0Uh7sl7qfP1IyILa8Z40ug==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@formatjs/ecma402-abstract": "2.3.4",
+        "@formatjs/fast-memoize": "2.2.7",
+        "@formatjs/icu-messageformat-parser": "2.11.2",
+        "tslib": "^2.8.0"
+      }
+    },
     "node_modules/is-array-buffer": {
       "version": "3.0.5",
       "resolved": "https://registry.npmjs.org/is-array-buffer/-/is-array-buffer-3.0.5.tgz",
@@ -6787,6 +6865,15 @@
       "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
       "dev": true
     },
+    "node_modules/negotiator": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-1.0.0.tgz",
+      "integrity": "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
     "node_modules/next": {
       "version": "14.2.31",
       "resolved": "https://registry.npmjs.org/next/-/next-14.2.31.tgz",
@@ -6832,6 +6919,33 @@
           "optional": true
         },
         "sass": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/next-intl": {
+      "version": "4.3.4",
+      "resolved": "https://registry.npmjs.org/next-intl/-/next-intl-4.3.4.tgz",
+      "integrity": "sha512-VWLIDlGbnL/o4LnveJTJD1NOYN8lh3ZAGTWw2krhfgg53as3VsS4jzUVnArJdqvwtlpU/2BIDbWTZ7V4o1jFEw==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/amannn"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@formatjs/intl-localematcher": "^0.5.4",
+        "negotiator": "^1.0.0",
+        "use-intl": "^4.3.4"
+      },
+      "peerDependencies": {
+        "next": "^12.0.0 || ^13.0.0 || ^14.0.0 || ^15.0.0",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || >=19.0.0-rc <19.0.0 || ^19.0.0",
+        "typescript": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
           "optional": true
         }
       }
@@ -9302,7 +9416,7 @@
       "version": "5.3.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.3.3.tgz",
       "integrity": "sha512-pXWcraxM0uxAS+tN0AG/BF2TyqmHO014Z070UsJ+pFvYuRSq8KH8DmWpnbXe0pEPDHXZV3FcAbJkijJ5oNEnWw==",
-      "dev": true,
+      "devOptional": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -9450,6 +9564,20 @@
         "@types/react": {
           "optional": true
         }
+      }
+    },
+    "node_modules/use-intl": {
+      "version": "4.3.4",
+      "resolved": "https://registry.npmjs.org/use-intl/-/use-intl-4.3.4.tgz",
+      "integrity": "sha512-sHfiU0QeJ1rirNWRxvCyvlSh9+NczcOzRnPyMeo2rtHXhVnBsvMRjE+UG4eh3lRhCxrvcqei/I0lBxsc59on1w==",
+      "license": "MIT",
+      "dependencies": {
+        "@formatjs/fast-memoize": "^2.2.0",
+        "@schummar/icu-type-parser": "1.21.5",
+        "intl-messageformat": "^10.5.14"
+      },
+      "peerDependencies": {
+        "react": "^17.0.0 || ^18.0.0 || >=19.0.0-rc <19.0.0 || ^19.0.0"
       }
     },
     "node_modules/use-sidecar": {

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "framer-motion": "10.16.0",
     "lucide-react": "^0.539.0",
     "next": "^14.2.31",
+    "next-intl": "^4.3.4",
     "next-themes": "0.3.0",
     "openai": "^5.12.2",
     "posthog-js": "^1.178.1",

--- a/tests/layout-skip-link.test.tsx
+++ b/tests/layout-skip-link.test.tsx
@@ -17,7 +17,8 @@ vi.mock("next-themes", () => ({ ThemeProvider: ({ children }: any) => <>{childre
 
 describe("RootLayout a11y", () => {
   it("includes a skip link and main landmark", async () => {
-    render(<RootLayout>{<div>Child</div>}</RootLayout>)
+    const element = await RootLayout({ children: <div>Child</div> })
+    render(element)
     const skip = await screen.findByRole("link", { name: /skip to content/i })
     expect(skip).toHaveAttribute("href", "#main")
     await waitFor(() => {

--- a/tests/pages/home-client.test.tsx
+++ b/tests/pages/home-client.test.tsx
@@ -2,6 +2,8 @@ import { describe, it, expect } from 'vitest'
 import React from 'react'
 import Home from '@/app/page'
 import { render } from '@testing-library/react'
+import { NextIntlClientProvider } from 'next-intl'
+import messages from '@/messages/en.json'
 import { vi } from 'vitest'
 vi.mock('@/components/ux/StartStoryPortal', () => ({ useStartStory: () => (()=>{}) }))
 
@@ -10,7 +12,11 @@ vi.mock('@/components/ux/StartStoryPortal', () => ({ useStartStory: () => (()=>{
 describe('Home page (client)', () => {
   it('renders without crashing and shows CTA', () => {
     // @ts-ignore server wrapper differences
-  const { getByText } = render(<Home />)
+    const { getByText } = render(
+      <NextIntlClientProvider locale="en" messages={messages}>
+        <Home />
+      </NextIntlClientProvider>
+    )
     expect(getByText('Start Color Story')).toBeTruthy()
   })
 })

--- a/tests/pages/home-hero.test.tsx
+++ b/tests/pages/home-hero.test.tsx
@@ -2,6 +2,8 @@ import React from 'react'
 import { describe, it, expect } from 'vitest'
 import Home from '@/app/page'
 import { render } from '@testing-library/react'
+import { NextIntlClientProvider } from 'next-intl'
+import messages from '@/messages/en.json'
 import { vi } from 'vitest'
 vi.mock('@/components/ux/StartStoryPortal', () => ({ useStartStory: () => (()=>{}) }))
 
@@ -10,7 +12,11 @@ vi.mock('@/components/ux/StartStoryPortal', () => ({ useStartStory: () => (()=>{
 describe('Home hero', () => {
   it('shows hero copy and CTA', () => {
     // @ts-ignore
-  const { getByText } = render(<Home />)
+    const { getByText } = render(
+      <NextIntlClientProvider locale="en" messages={messages}>
+        <Home />
+      </NextIntlClientProvider>
+    )
     expect(getByText('instant color confidence')).toBeTruthy()
     expect(getByText('from vibe to walls in minutes.')).toBeTruthy()
     expect(getByText('real paint codes. clear placements.')).toBeTruthy()

--- a/tests/pages/home-howitworks-link.test.tsx
+++ b/tests/pages/home-howitworks-link.test.tsx
@@ -2,13 +2,19 @@ import React from 'react'
 import { describe, it, expect } from 'vitest'
 import Home from '@/app/page'
 import { render } from '@testing-library/react'
+import { NextIntlClientProvider } from 'next-intl'
+import messages from '@/messages/en.json'
 import { vi } from 'vitest'
 vi.mock('@/components/ux/StartStoryPortal', () => ({ useStartStory: () => (()=>{}) }))
 
 describe("Home 'How it works' trigger", () => {
   it('shows how it works button', () => {
     // @ts-ignore
-  const { getByText } = render(<Home />)
+    const { getByText } = render(
+      <NextIntlClientProvider locale="en" messages={messages}>
+        <Home />
+      </NextIntlClientProvider>
+    )
     expect(getByText('How it works')).toBeTruthy()
   })
 })


### PR DESCRIPTION
## Summary
- add next-intl and locale detection utility
- wrap root layout with I18n provider
- extract Home and SignIn page strings to translation files
- document translation workflow and provide Spanish sample

## Testing
- `npm run lint`
- `npm test` *(fails: Cinematic reveal > renders and exits on Esc)*

------
https://chatgpt.com/codex/tasks/task_e_689ae438223483228d693e855b33edf9