### PR TITLE
Add culori type declarations to fix build error

### DIFF
--- a/types/culori.d.ts
+++ b/types/culori.d.ts
@@ -1,0 +1,13 @@
+declare module 'culori' {
+  interface Lab65Color {
+    mode: 'lab65';
+    l: number;
+    a: number;
+    b: number;
+  }
+
+  export function differenceCiede2000(): (
+    c1: Lab65Color,
+    c2: Lab65Color
+  ) => number;
+}


### PR DESCRIPTION
## Summary
- add custom TypeScript declaration for `culori`

## Testing
- `npm test` *(fails: spy not called)*
- `npm run lint`
- `npm run build` *(fails: couldn't find next-intl config file)*

------
https://chatgpt.com/codex/tasks/task_e_689b4728597c8322b24aa126a7cd8db2