### PR TITLE
Configure next-intl and lazy OpenAI client

### DIFF
--- a/app/api/vision/analyze/route.ts
+++ b/app/api/vision/analyze/route.ts
@@ -1,12 +1,14 @@
 import OpenAI from "openai";
 import { NextRequest } from "next/server";
-const client = new OpenAI({ apiKey: process.env.OPENAI_API_KEY });
 
 export async function POST(req: NextRequest) {
   try {
     const { imageUrl } = await req.json();
     if (!imageUrl) return new Response(JSON.stringify({ error: "imageUrl required" }), { status: 400 });
 
+    const apiKey = process.env.OPENAI_API_KEY;
+    if (!apiKey) return new Response(JSON.stringify({ error: "missing OpenAI API key" }), { status: 500 });
+    const client = new OpenAI({ apiKey });
     const res = await client.responses.create({
       model: process.env.OPENAI_MODEL || "gpt-4o-mini",
       input: [

--- a/components/reveal/Cinematic.tsx
+++ b/components/reveal/Cinematic.tsx
@@ -1,5 +1,5 @@
 "use client"
-import React, { useEffect, useRef, useState } from 'react'
+import React, { useEffect, useRef, useState, useCallback } from 'react'
 import { motion, AnimatePresence } from 'framer-motion'
 import * as Dialog from '@radix-ui/react-dialog'
 import { useReducedMotion } from '@/components/theme/MotionSettings'
@@ -15,7 +15,14 @@ export default function Cinematic({ open, onExit, story }: CinematicProps){
     const t = setInterval(()=>{ if(startRef.current) setElapsed((performance.now()-startRef.current)/1000) },500)
     return ()=>clearInterval(t)
   },[open, story.id])
-  function end(){ track('cinematic_exit',{ id:story.id, seconds:Number(elapsed.toFixed(1)) }); onExit() }
+  const end = useCallback(()=>{ track('cinematic_exit',{ id:story.id, seconds:Number(elapsed.toFixed(1)) }); onExit() },[elapsed, onExit, story.id])
+  useEffect(()=>{
+    function handleKey(e:KeyboardEvent){ if(e.key==='Escape') end() }
+    if(open){
+      window.addEventListener('keydown', handleKey)
+      return ()=> window.removeEventListener('keydown', handleKey)
+    }
+  },[open, end])
   const palette = story.palette || []
   const reduce = useReducedMotion()
   return (

--- a/i18n/request.ts
+++ b/i18n/request.ts
@@ -1,0 +1,13 @@
+import {getRequestConfig} from 'next-intl/server'
+import {defaultLocale, locales} from '../lib/i18n'
+
+export default getRequestConfig(async ({requestLocale}) => {
+  let locale = (await requestLocale) ?? defaultLocale
+  if (!locales.includes(locale as typeof locales[number])) {
+    locale = defaultLocale
+  }
+  return {
+    locale,
+    messages: (await import(`../messages/${locale}.json`)).default
+  }
+})

--- a/next.config.js
+++ b/next.config.js
@@ -1,6 +1,11 @@
+let withNextIntl = (config) => config
+if (process.env.VITEST_WORKER_ID == null) {
+  const createNextIntlPlugin = require('next-intl/plugin')
+  withNextIntl = createNextIntlPlugin('./i18n/request.ts')
+}
+
 /** @type {import('next').NextConfig} */
 const nextConfig = {
-  i18n: { locales: ['en', 'es'], defaultLocale: 'en' },
   reactStrictMode: true,
   async redirects() {
     return [
@@ -10,4 +15,4 @@ const nextConfig = {
   }
 }
 
-module.exports = nextConfig
+module.exports = withNextIntl(nextConfig)


### PR DESCRIPTION
## Summary
- configure next-intl via request config and plugin wrapper
- add global escape key listener for cinematic reveal
- defer OpenAI client creation until request time

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689b4cdc274483228b4cb3aef0e7c631