### PR TITLE
fix: improve text readability

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -41,19 +41,27 @@ a, button, [role="button"] { outline-offset: 3px; }
 
 @layer base {
   :root {
-    /* Keep existing background tokens as-is (brand dark stays). 
-       We only correct foregrounds for readability. */
-    /* Light-on-dark default text for brand background */
-    --foreground: 0 0% 98%;
-    --muted-foreground: 210 16% 85%;
-    --secondary-foreground: 210 16% 92%;
-    --accent-foreground: 0 0% 100%;
+    /* Preserve existing background tokens; adjust text for readability */
+    --foreground: 222 47% 11%;
+    --muted-foreground: 215 16% 35%;
+    --secondary-foreground: 215 16% 46%;
+    --accent-foreground: 0 0% 98%;
 
     /* Cards/popovers stay light surfaces with dark text */
     --card: 0 0% 100%;
     --card-foreground: 222 47% 11%;
     --popover: 0 0% 100%;
     --popover-foreground: 222 47% 11%;
+  }
+
+  @media (prefers-color-scheme: dark) {
+    :root {
+      /* Light text on dark backgrounds */
+      --foreground: 0 0% 98%;
+      --muted-foreground: 210 16% 85%;
+      --secondary-foreground: 210 16% 92%;
+      --accent-foreground: 0 0% 100%;
+    }
   }
 
   /* Ensure base text always honors our tokens */

--- a/tests/a11y.tokens.test.ts
+++ b/tests/a11y.tokens.test.ts
@@ -4,6 +4,7 @@ import { join } from 'node:path';
 describe('a11y tokens', () => {
   it('globals.css defines readable foreground tokens', () => {
     const css = readFileSync(join(process.cwd(), 'app/globals.css'), 'utf8');
+    expect(css).toMatch(/--foreground:\s*222 47% 11%/);
     expect(css).toMatch(/--foreground:\s*0 0% 98%/);
     expect(css).toMatch(/--card-foreground:\s*222 47% 11%/);
   });


### PR DESCRIPTION
## Summary
- adjust global foreground token defaults for light surfaces and add dark mode override for contrast
- update a11y token tests to verify both light and dark foreground values

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689b530b26548322a998f4e84552b741