### PR TITLE
feat: leverage culori ΔE2000 for variant logic

### DIFF
--- a/lib/ai/color.ts
+++ b/lib/ai/color.ts
@@ -38,10 +38,11 @@ export function hexToLab(hex: string): LAB {
   return { L, a, b: b2 }
 }
 
-const de00 = differenceCiede2000()
+// Precompute culori's ΔE2000 comparator
+const deltaE2000 = differenceCiede2000()
 
 export function deltaE(l1: LAB, l2: LAB): number {
-  return de00(
+  return deltaE2000(
     { mode: 'lab65', l: l1.L, a: l1.a, b: l1.b },
     { mode: 'lab65', l: l2.L, a: l2.a, b: l2.b }
   )

--- a/lib/ai/variants.ts
+++ b/lib/ai/variants.ts
@@ -41,8 +41,11 @@ export function makeVariant(base: Swatch[], _brand: Brand, tweak: Tweak): Swatch
       hex = shift(hex, tweak==='softer'? 'softer':'bolder', 0.12)
       // accent vs walls ≥2:1 and visibly different
       if (wallsHex) {
-        let tries=0
-        while ((contrastRatio(hex, wallsHex) < 2 || deltaEHex(hex, wallsHex) < 10) && tries<10) {
+        let tries = 0
+        while (tries < 10) {
+          const ratio = contrastRatio(hex, wallsHex)
+          const diff = deltaEHex(hex, wallsHex)
+          if (ratio >= 2 && diff >= 10) break
           hex = shift(hex, tweak==='softer'? 'softer':'bolder', 0.06)
           tries++
         }

--- a/tests/ai.test.ts
+++ b/tests/ai.test.ts
@@ -25,6 +25,13 @@ describe('deltaE', () => {
     expect(deltaEHex('#000000', '#ffffff')).toBeCloseTo(deltaEHex('#ffffff', '#000000'), 5)
     expect(far).toBeGreaterThan(near)
   })
+  it('detects very small differences', () => {
+    expect(deltaEHex('#000000', '#010101')).toBeLessThan(1)
+  })
+  it('matches reference values', () => {
+    expect(deltaEHex('#ff0000', '#00ff00')).toBeCloseTo(86.6, 1)
+    expect(deltaEHex('#000000', '#ffffff')).toBeCloseTo(100, 5)
+  })
 })
 
 describe('variants', () => {


### PR DESCRIPTION
## Summary
- use culori's ΔE2000 comparator in color utilities
- apply ΔE2000 to accent contrast logic in variant generation
- add deltaE edge-case tests

## Testing
- `npm test tests/ai.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_689b55e669f4832284c3a454b9494f12