### PR TITLE
refactor: extract intake chat hook

### DIFF
--- a/components/ai/OnboardingChat.tsx
+++ b/components/ai/OnboardingChat.tsx
@@ -1,87 +1,10 @@
-'use client'
+"use client"
 import * as React from 'react'
-import { useRouter } from 'next/navigation'
+import { useIntakeChat } from '@/lib/hooks/useIntakeChat'
 
 export default function OnboardingChat({ designerId }: { designerId: string }) {
-  const router = useRouter()
-  const startedRef = React.useRef(false)
-  const [sessionId, setSessionId] = React.useState<string | null>(null)
-  const [currentNode, setCurrentNode] = React.useState<any | null>(null)
-  const [input, setInput] = React.useState('')
-  const [busy, setBusy] = React.useState(false)
-  const [done, setDone] = React.useState(false)
-  const [statusText, setStatusText] = React.useState<string | null>(null)
+  const { currentNode, input, setInput, busy, done, statusText, submit } = useIntakeChat(designerId)
   const API_MODE = process.env.NEXT_PUBLIC_ONBOARDING_MODE === 'api'
-
-  React.useEffect(() => {
-    if (!API_MODE || startedRef.current) return
-    startedRef.current = true
-    let alive = true
-    ;(async () => {
-      const r = await fetch('/api/intakes/start', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ designerId })
-      })
-      const j = await r.json().catch(() => null)
-      if (!alive) return
-      setSessionId(j?.sessionId ?? null)
-      setCurrentNode(j?.step?.type === 'question' ? j.step.node : null)
-    })()
-    return () => { alive = false }
-  }, [designerId])
-
-  async function submit(value?: string) {
-    const v = (value ?? input).trim()
-    if (!v || busy || done) return
-    if (!API_MODE) return
-    if (!sessionId || !currentNode) return
-    setBusy(true)
-    try {
-      const r = await fetch('/api/intakes/step', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ sessionId, answer: v })
-      })
-      const j = await r.json().catch(() => null)
-      if (j?.step?.type === 'question') {
-        setCurrentNode(j.step.node)
-        setInput('')
-        setBusy(false)
-        return
-      }
-        setStatusText('Great — generating your palette now…')
-        const fin = await fetch('/api/intakes/finalize', {
-          method: 'POST',
-          headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({ sessionId })
-        })
-        const data = await fin.json().catch(() => null)
-        let create: Response | null = null
-        try {
-          create = await fetch('/api/stories', {
-            method: 'POST',
-            headers: { 'Content-Type': 'application/json' },
-            body: JSON.stringify({
-              designerKey: designerId,
-              brand: data?.input?.brand,
-              palette_v2: data?.palette_v2,
-              seed: `intake:${sessionId}`
-            })
-          })
-        } catch {}
-        const story = create ? await create.json().catch(() => null) : null
-      setDone(true)
-      if (story?.id) router.push(`/reveal/${story.id}`)
-    } catch (e) {
-      console.error('ONBOARDING_API_FLOW_FAIL', e)
-      setBusy(false)
-    }
-  }
-
-  function onQuickReply(v: string) {
-    submit(v)
-  }
 
   if (!API_MODE) return null
 
@@ -101,7 +24,7 @@ export default function OnboardingChat({ designerId }: { designerId: string }) {
             <button
               key={o}
               disabled={busy}
-              onClick={() => onQuickReply(o)}
+              onClick={() => submit(o)}
               className="rounded-full border border-white/20 bg-white/10 px-3 py-1 text-sm hover:bg-white/15 disabled:opacity-50"
             >
               {o}
@@ -114,7 +37,9 @@ export default function OnboardingChat({ designerId }: { designerId: string }) {
           <input
             value={input}
             onChange={(e) => setInput(e.target.value)}
-            onKeyDown={(e) => { if (e.key === 'Enter') submit(input) }}
+            onKeyDown={(e) => {
+              if (e.key === 'Enter') submit(input)
+            }}
             disabled={busy}
             placeholder="Say it or type it…"
             className="flex-1 rounded-xl bg-white/10 px-3 py-2 text-sm outline-none placeholder:text-white/60"

--- a/lib/hooks/useIntakeChat.ts
+++ b/lib/hooks/useIntakeChat.ts
@@ -1,0 +1,105 @@
+'use client'
+
+import { useEffect, useRef, useState } from 'react'
+import { useRouter } from 'next/navigation'
+
+export interface IntakeNode {
+  question?: string
+  options?: string[]
+  [key: string]: any
+}
+
+export interface UseIntakeChat {
+  currentNode: IntakeNode | null
+  input: string
+  setInput: (v: string) => void
+  busy: boolean
+  done: boolean
+  statusText: string | null
+  submit: (value?: string) => Promise<void>
+}
+
+export function useIntakeChat(designerId: string): UseIntakeChat {
+  const router = useRouter()
+  const startedRef = useRef(false)
+  const [sessionId, setSessionId] = useState<string | null>(null)
+  const [currentNode, setCurrentNode] = useState<IntakeNode | null>(null)
+  const [input, setInput] = useState('')
+  const [busy, setBusy] = useState(false)
+  const [done, setDone] = useState(false)
+  const [statusText, setStatusText] = useState<string | null>(null)
+  const API_MODE = process.env.NEXT_PUBLIC_ONBOARDING_MODE === 'api'
+
+  useEffect(() => {
+    if (!API_MODE || startedRef.current) return
+    startedRef.current = true
+    let alive = true
+    ;(async () => {
+      try {
+        const r = await fetch('/api/intakes/start', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ designerId })
+        })
+        const j = await r.json().catch(() => null)
+        if (!alive) return
+        setSessionId(j?.sessionId ?? null)
+        setCurrentNode(j?.step?.type === 'question' ? j.step.node : null)
+      } catch {}
+    })()
+    return () => {
+      alive = false
+    }
+  }, [designerId, API_MODE])
+
+  async function submit(value?: string) {
+    const v = (value ?? input).trim()
+    if (!v || busy || done) return
+    if (!API_MODE) return
+    if (!sessionId || !currentNode) return
+    setBusy(true)
+    try {
+      const r = await fetch('/api/intakes/step', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ sessionId, answer: v })
+      })
+      const j = await r.json().catch(() => null)
+      if (j?.step?.type === 'question') {
+        setCurrentNode(j.step.node)
+        setInput('')
+        setBusy(false)
+        return
+      }
+      setStatusText('Great — generating your palette now…')
+      const fin = await fetch('/api/intakes/finalize', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ sessionId })
+      })
+      const data = await fin.json().catch(() => null)
+      let create: Response | null = null
+      try {
+        create = await fetch('/api/stories', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({
+            designerKey: designerId,
+            brand: data?.input?.brand,
+            palette_v2: data?.palette_v2,
+            seed: `intake:${sessionId}`
+          })
+        })
+      } catch {}
+      const story = create ? await create.json().catch(() => null) : null
+      setDone(true)
+      if (story?.id) router.push(`/reveal/${story.id}`)
+    } catch (e) {
+      console.error('ONBOARDING_API_FLOW_FAIL', e)
+      setBusy(false)
+    }
+  }
+
+  return { currentNode, input, setInput, busy, done, statusText, submit }
+}
+

--- a/tests/lib/use-intake-chat.test.ts
+++ b/tests/lib/use-intake-chat.test.ts
@@ -1,0 +1,82 @@
+import { describe, it, expect, vi } from 'vitest'
+import { renderHook, act, waitFor } from '@testing-library/react'
+import { useIntakeChat } from '@/lib/hooks/useIntakeChat'
+
+vi.mock('next/navigation', () => ({
+  useRouter: () => ({ push: vi.fn() })
+}))
+
+// Ensure API mode
+// @ts-ignore
+process.env.NEXT_PUBLIC_ONBOARDING_MODE = 'api'
+
+describe('useIntakeChat', () => {
+  it('advances through questions and finalizes', async () => {
+    const fetchMock = vi
+      .fn()
+      // start
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({ sessionId: 'sess1', step: { type: 'question', node: { question: 'Brand?', options: ['SW'] } } })
+        )
+      )
+      // step -> done
+      .mockResolvedValueOnce(new Response(JSON.stringify({ step: { type: 'done' } })))
+      // finalize
+      .mockResolvedValueOnce(new Response(JSON.stringify({ input: { brand: 'SW' }, palette_v2: {} })))
+      // create story
+      .mockResolvedValueOnce(new Response(JSON.stringify({ id: 'story1' })))
+    // @ts-ignore
+    global.fetch = fetchMock
+
+    const { result } = renderHook(() => useIntakeChat('emily'))
+    await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(1))
+    expect(result.current.currentNode?.question).toBe('Brand?')
+
+    await act(async () => {
+      await result.current.submit('SW')
+    })
+
+    await waitFor(() => expect(fetchMock).toHaveBeenCalledWith('/api/intakes/finalize', expect.any(Object)))
+    expect(result.current.done).toBe(true)
+  })
+
+  it('handles intermediate questions', async () => {
+    const fetchMock = vi
+      .fn()
+      // start
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({ sessionId: 'sess1', step: { type: 'question', node: { question: 'Brand?' } } })
+        )
+      )
+      // step -> another question
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({ step: { type: 'question', node: { question: 'Vibe?' } } })
+        )
+      )
+      // step -> done
+      .mockResolvedValueOnce(new Response(JSON.stringify({ step: { type: 'done' } })))
+      // finalize
+      .mockResolvedValueOnce(new Response(JSON.stringify({ input: {}, palette_v2: {} })))
+      // create story
+      .mockResolvedValueOnce(new Response(JSON.stringify({ id: 'story1' })))
+    // @ts-ignore
+    global.fetch = fetchMock
+
+    const { result } = renderHook(() => useIntakeChat('emily'))
+    await waitFor(() => expect(result.current.currentNode?.question).toBe('Brand?'))
+
+    await act(async () => {
+      await result.current.submit('Sherwin')
+    })
+    await waitFor(() => expect(result.current.currentNode?.question).toBe('Vibe?'))
+
+    await act(async () => {
+      await result.current.submit('Cozy')
+    })
+    await waitFor(() => expect(result.current.done).toBe(true))
+  })
+})
+


### PR DESCRIPTION
## Summary
- factor session start, step submission, and finalize logic into `useIntakeChat` hook
- refactor `OnboardingChat` component to use the shared hook
- add unit tests covering hook state transitions

## Testing
- `npm test tests/lib/use-intake-chat.test.ts tests/ai/onboarding-api-flow.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_689b66abaf308322b92e25b40463a9a8