### PR TITLE
Apply system prompt to realtime voice session

### DIFF
--- a/app/api/realtime/offer/route.ts
+++ b/app/api/realtime/offer/route.ts
@@ -2,14 +2,15 @@ import { NextRequest } from "next/server";
 
 export async function POST(req: NextRequest) {
   try {
-    const { sdp, model } = await req.json();
+    const { sdp, model, token } = await req.json();
     if (!sdp) return new Response(JSON.stringify({ error: "Missing sdp" }), { status: 400 });
 
     const mdl = model || process.env.OPENAI_REALTIME_MODEL || "gpt-4o-realtime-preview-2024-12-17";
+    const auth = token ? `Bearer ${token}` : `Bearer ${process.env.OPENAI_API_KEY}`;
     const r = await fetch(`https://api.openai.com/v1/realtime?model=${encodeURIComponent(mdl)}`, {
       method: "POST",
       headers: {
-        Authorization: `Bearer ${process.env.OPENAI_API_KEY}`,
+        Authorization: auth,
         "Content-Type": "application/sdp",
       },
       body: sdp,

--- a/app/api/realtime/session/route.ts
+++ b/app/api/realtime/session/route.ts
@@ -1,4 +1,5 @@
 import { NextRequest } from "next/server";
+import SYSTEM_PROMPT from "@/lib/prompt/system";
 
 /**
  * POST /api/realtime/session
@@ -24,11 +25,8 @@ export async function POST(req: NextRequest) {
       body: JSON.stringify({
         model: rtModel,
         voice: rtVoice,
-        // Keep the agent quiet unless we send response.create over the data channel.
-        instructions:
-          "You are the voice of Colrvia. Do NOT ask your own questions. " +
-          "Only speak the exact text you receive via response.create events. " +
-          "Keep replies warm, brief, and natural. If no event arrives, stay silent."
+        instructions: SYSTEM_PROMPT +
+          "\n\nKeep replies warm, brief, and natural."
       }),
     });
 


### PR DESCRIPTION
## Summary
- Use Colrvia system prompt when creating realtime voice session
- Pass session token through offer relay and VoiceMic client
## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689b65f3b7f083228bc2e4cbe5165dd7