### PR TITLE
feat: queue analytics events offline

### DIFF
--- a/lib/analytics.ts
+++ b/lib/analytics.ts
@@ -41,6 +41,10 @@ function flushQueue() {
   writeQueue([])
 }
 
+function handleSwMessage(e: MessageEvent){
+  if(e.data === 'online') flushQueue()
+}
+
 export function initAnalytics(){
   if(typeof window === 'undefined') return
   if(client) return client
@@ -54,9 +58,7 @@ export function initAnalytics(){
     flushQueue()
   })
   window.addEventListener('online', flushQueue)
-  navigator.serviceWorker?.addEventListener('message', e => {
-    if (e.data === 'online') flushQueue()
-  })
+  navigator.serviceWorker?.addEventListener('message', handleSwMessage)
   return client
 }
 

--- a/public/sw.js
+++ b/public/sw.js
@@ -43,9 +43,8 @@ self.addEventListener('fetch',event=>{
   }
 });
 
-self.addEventListener('online',()=>{
-  self.clients.matchAll().then(clients=>clients.forEach(c=>c.postMessage('online')))
-});
-self.addEventListener('offline',()=>{
-  self.clients.matchAll().then(clients=>clients.forEach(c=>c.postMessage('offline')))
-});
+function broadcastStatus(status){
+  self.clients.matchAll().then(clients=>clients.forEach(c=>c.postMessage(status)))
+}
+self.addEventListener('online',()=>broadcastStatus('online'));
+self.addEventListener('offline',()=>broadcastStatus('offline'));

--- a/tests/lib/analytics.offline.test.ts
+++ b/tests/lib/analytics.offline.test.ts
@@ -36,4 +36,25 @@ describe('analytics offline queue', () => {
     expect(localStorage.getItem('ph_queue')).toBeNull()
     onlineSpy.mockRestore()
   })
+
+  it('flushes queued events when service worker reports online', async () => {
+    const onlineSpy = vi.spyOn(navigator, 'onLine', 'get').mockReturnValue(false)
+    const sw = new EventTarget()
+    Object.defineProperty(navigator, 'serviceWorker', { value: sw, configurable: true })
+    const analytics = await import('@/lib/analytics')
+    analytics.track('nav_click', { dest: '/bar' })
+    expect(JSON.parse(localStorage.getItem('ph_queue') || '[]')).toHaveLength(1)
+
+    await new Promise(r => setTimeout(r))
+    const posthog = (await import('posthog-js')).default as any
+    expect(posthog.capture).not.toHaveBeenCalled()
+
+    onlineSpy.mockReturnValue(true)
+    sw.dispatchEvent(new MessageEvent('message', { data: 'online' }))
+
+    expect(posthog.capture).toHaveBeenCalledWith('nav_click', { dest: '/bar' })
+    expect(localStorage.getItem('ph_queue')).toBeNull()
+    onlineSpy.mockRestore()
+    delete (navigator as any).serviceWorker
+  })
 })


### PR DESCRIPTION
## Summary
- add localStorage-backed queue for analytics events with SW notification
- broadcast online/offline from service worker
- test offline analytics queue flushing via service worker message

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689b61b603c883228cc897fb29a0004d