### PR TITLE
Add i18n provider and locale files

### DIFF
--- a/app/error.tsx
+++ b/app/error.tsx
@@ -2,6 +2,8 @@
 
 import React, { useEffect } from "react"
 import Link from "next/link"
+import { useTranslations } from 'next-intl'
+import enMessages from '@/messages/en.json'
 
 export default function GlobalError({
   error,
@@ -13,14 +15,21 @@ export default function GlobalError({
   useEffect(() => {
     // console.error(error)
   }, [error])
+  let t
+  try {
+    t = useTranslations('ErrorPage')
+  } catch {
+    const m = (enMessages as any).ErrorPage
+    t = (key: string) => m[key]
+  }
 
   return (
     <html>
       <body className="min-h-dvh bg-background text-foreground">
         <main className="mx-auto max-w-xl p-6 md:p-8 space-y-4 text-center">
-          <h1 className="text-2xl md:text-3xl font-semibold">Something went sideways</h1>
+          <h1 className="text-2xl md:text-3xl font-semibold">{t('title')}</h1>
           <p className="text-sm text-muted-foreground">
-            We ran into an error while rendering this page. You can try again or head back to Start.
+            {t('description')}
           </p>
 
           <div className="flex items-center justify-center gap-3">
@@ -28,13 +37,13 @@ export default function GlobalError({
               onClick={() => reset()}
               className="inline-flex items-center justify-center rounded-2xl px-4 py-2 border border-border focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-[var(--ring)] ring-offset-[var(--surface)]"
             >
-              Try again
+              {t('tryAgain')}
             </button>
             <Link
               href="/start"
               className="inline-flex items-center justify-center rounded-2xl px-4 py-2 bg-primary text-primary-foreground hover:opacity-90 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-[var(--ring)] ring-offset-[var(--surface)]"
             >
-              Go to Start
+              {t('goStart')}
             </Link>
           </div>
 

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -12,7 +12,8 @@ import { Analytics } from '@vercel/analytics/react'
 import { MotionProvider } from '@/components/theme/MotionSettings'
 import AmbientEdge from '@/components/ui/ambient-edge'
 import dynamic from 'next/dynamic'
-import { NextIntlClientProvider, createTranslator } from 'next-intl'
+import { createTranslator } from 'next-intl'
+import I18nProvider from '@/components/providers/I18nProvider'
 import { getLocale, getMessages } from '@/lib/i18n'
 
 const RouteTransition = dynamic(() => import('@/components/ux/RouteTransition'), { ssr:false })
@@ -67,7 +68,7 @@ export default async function RootLayout({
         <meta name="theme-color" media="(prefers-color-scheme: dark)" content="#121212" />
       </head>
       <body className="min-h-screen bg-background text-foreground antialiased font-sans">
-        <NextIntlClientProvider locale={locale} messages={messages}>
+        <I18nProvider locale={locale} messages={messages}>
           {/* Skip link for keyboard users */}
           <a
             href="#main"
@@ -109,7 +110,7 @@ export default async function RootLayout({
             speedSeconds={16}
             opacity={0.55}
           />
-        </NextIntlClientProvider>
+        </I18nProvider>
       </body>
     </html>
   )

--- a/app/not-found.tsx
+++ b/app/not-found.tsx
@@ -1,25 +1,35 @@
+"use client"
 import React from "react"
 import Link from "next/link"
+import { useTranslations } from 'next-intl'
+import enMessages from '@/messages/en.json'
 
 export default function NotFound() {
+  let t
+  try {
+    t = useTranslations('NotFoundPage')
+  } catch {
+    const m = (enMessages as any).NotFoundPage
+    t = (key: string) => m[key]
+  }
   return (
     <main className="mx-auto max-w-xl p-6 md:p-8 space-y-4 text-center">
-      <h1 className="text-2xl md:text-3xl font-semibold">We couldn’t find that</h1>
+      <h1 className="text-2xl md:text-3xl font-semibold">{t('title')}</h1>
       <p className="text-sm text-muted-foreground">
-        The page you’re looking for doesn’t exist or has moved.
+        {t('description')}
       </p>
       <div className="flex items-center justify-center gap-3">
         <Link
           href="/"
           className="inline-flex items-center justify-center rounded-2xl px-4 py-2 border border-border hover:opacity-90 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-[var(--ring)] ring-offset-[var(--surface)]"
         >
-          Go Home
+          {t('goHome')}
         </Link>
         <Link
           href="/start"
           className="inline-flex items-center justify-center rounded-2xl px-4 py-2 bg-primary text-primary-foreground hover:opacity-90 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-[var(--ring)] ring-offset-[var(--surface)]"
         >
-          Start a Color Story
+          {t('startStory')}
         </Link>
       </div>
     </main>

--- a/components/providers/I18nProvider.tsx
+++ b/components/providers/I18nProvider.tsx
@@ -1,0 +1,18 @@
+"use client"
+
+import React, { ReactNode } from 'react'
+import { NextIntlClientProvider } from 'next-intl'
+
+interface Props {
+  locale: string
+  messages: Record<string, any>
+  children: ReactNode
+}
+
+export default function I18nProvider({ locale, messages, children }: Props) {
+  return (
+    <NextIntlClientProvider locale={locale} messages={messages}>
+      {children}
+    </NextIntlClientProvider>
+  )
+}

--- a/docs/TRANSLATION.md
+++ b/docs/TRANSLATION.md
@@ -2,6 +2,8 @@
 
 This project uses [`next-intl`](https://next-intl.dev/) for internationalization.
 
+Translations are loaded in `app/layout.tsx` via an `I18nProvider` that uses the locale detection helpers from [`lib/i18n.ts`](../lib/i18n.ts).
+
 ## Adding or updating translations
 
 1. Edit `messages/en.json` with any new keys.

--- a/lib/i18n.ts
+++ b/lib/i18n.ts
@@ -1,5 +1,11 @@
 import { headers } from 'next/headers'
 
+/**
+ * Internationalization helpers used by the I18nProvider.
+ * Detects the user's locale from the `Accept-Language` header
+ * and loads the corresponding translation messages.
+ */
+
 export const locales = ['en', 'es'] as const
 export type Locale = (typeof locales)[number]
 export const defaultLocale: Locale = 'en'

--- a/messages/en.json
+++ b/messages/en.json
@@ -47,5 +47,17 @@
       "confirmationResent": "Confirmation email resent. Check inbox & spam.",
       "couldNotResend": "Could not resend confirmation email"
     }
+  },
+  "NotFoundPage": {
+    "title": "We couldn’t find that",
+    "description": "The page you’re looking for doesn’t exist or has moved.",
+    "goHome": "Go Home",
+    "startStory": "Start a Color Story"
+  },
+  "ErrorPage": {
+    "title": "Something went sideways",
+    "description": "We ran into an error while rendering this page. You can try again or head back to Start.",
+    "tryAgain": "Try again",
+    "goStart": "Go to Start"
   }
 }

--- a/messages/es.json
+++ b/messages/es.json
@@ -47,5 +47,17 @@
       "confirmationResent": "Correo de confirmación reenviado. Revisa bandeja y spam.",
       "couldNotResend": "No se pudo reenviar el correo de confirmación"
     }
+  },
+  "NotFoundPage": {
+    "title": "No pudimos encontrar eso",
+    "description": "La página que buscas no existe o se ha movido.",
+    "goHome": "Ir al inicio",
+    "startStory": "Iniciar una historia de color"
+  },
+  "ErrorPage": {
+    "title": "Algo salió mal",
+    "description": "Encontramos un error al renderizar esta página. Puedes intentarlo de nuevo o volver a Inicio.",
+    "tryAgain": "Intentar de nuevo",
+    "goStart": "Ir a Inicio"
   }
 }


### PR DESCRIPTION
## Summary
- wrap app with custom I18nProvider powered by next-intl
- extract error and not-found messages into locale files
- document translation workflow and provide Spanish example

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689b66a9f890832280e96ad5aa3bd7bd