### PR TITLE
Add intake flow Playwright test

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,6 +122,13 @@ Run `npm test` to execute vitest suite verifying contrast rules & variant shifts
 ## UI Component Tests
 Initial UI tests live in `tests/ui/`. Add new tests colocated under `tests/ui/your-component.test.tsx`. The test environment is jsdom (configured in `vite.config.ts`) with jest‑dom assertions (`tests/setup.ts`). Keep component APIs small and accessible (roles / aria-* used in assertions).
 
+## End-to-end Tests
+Playwright drives browser-based flows. Before running:
+- install browsers with `npx playwright install`
+- set `NEXT_PUBLIC_SUPABASE_URL`, `NEXT_PUBLIC_SUPABASE_ANON_KEY`, and `NEXT_PUBLIC_ONBOARDING_MODE=api`
+
+Then run `npm run test:e2e`.
+
 ## Component Library Snapshot
 Key primitives: `Button`, `Chip`, `Progress`, `DesignerCard`, `SummaryCard`, `SwatchCard`, `PaletteGrid`, `StoryActionBar`, `CopyToast`. Each aims for:
 1. Minimal props surface

--- a/components/ai/OnboardingChat.tsx
+++ b/components/ai/OnboardingChat.tsx
@@ -86,7 +86,7 @@ export default function OnboardingChat({ designerId }: { designerId: string }) {
   if (!API_MODE) return null
 
   return (
-    <div className="rounded-2xl border border-white/15 bg-white/5 p-4 text-white/95">
+    <div role="dialog" aria-label="Preferences chat" className="rounded-2xl border border-white/15 bg-white/5 p-4 text-white/95">
       <div className="min-h-[120px]">
         {currentNode?.question ? (
           <p className="text-base md:text-lg">{currentNode.question}</p>

--- a/e2e/intake-flow.pw.ts
+++ b/e2e/intake-flow.pw.ts
@@ -1,0 +1,55 @@
+import { test, expect } from "@playwright/test"
+
+test.describe("Intake flow", () => {
+  test("designer selection, chat progression, and reveal redirect", async ({ page }) => {
+    await page.route("**/api/intakes/start", route =>
+      route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({
+          sessionId: "sess1",
+          step: {
+            type: "question",
+            node: { question: "Which room?", options: ["Living room", "Bedroom"] }
+          }
+        })
+      })
+    )
+
+    await page.route("**/api/intakes/step", route =>
+      route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({ step: { type: "done" } })
+      })
+    )
+
+    await page.route("**/api/intakes/finalize", route =>
+      route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({ input: { brand: "SW" }, palette_v2: [] })
+      })
+    )
+
+    await page.route("**/api/stories", route =>
+      route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({ id: "story-123" })
+      })
+    )
+
+    await page.goto("/designers")
+    await page.getByRole("link", { name: /start with color therapist/i }).click()
+
+    await expect(page).toHaveURL(/\/preferences\/therapist$/)
+    const chat = page.getByRole("dialog", { name: "Preferences chat" })
+    await expect(chat).toBeVisible()
+    await expect(page.getByText("Which room?")).toBeVisible()
+
+    await page.getByRole("button", { name: "Living room" }).click()
+
+    await expect(page).toHaveURL(/\/reveal\/story-123$/)
+  })
+})

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -16,6 +16,11 @@ export default defineConfig({
     url: 'http://localhost:3000',
     reuseExistingServer: !process.env.CI,
     timeout: 120_000,
+    env: {
+      NEXT_PUBLIC_SUPABASE_URL: 'http://localhost:54321',
+      NEXT_PUBLIC_SUPABASE_ANON_KEY: 'anon',
+      NEXT_PUBLIC_ONBOARDING_MODE: 'api',
+    },
   },
   projects: [
     { name: 'chromium', use: { ...devices['Desktop Chrome'] } },


### PR DESCRIPTION
## Summary
- mark onboarding chat as a dialog for accessibility
- add deterministic Playwright intake flow test with mocked APIs
- document and configure e2e test prerequisites

## Testing
- `npm test`
- `npm run test:e2e` *(fails: Designers slug redirects › therapist redirects to start with guide, Designers slug redirects › mae redirects to start with guide, Designers slug redirects › naturalist redirects to start with guide, Intake flow › designer selection, chat progression, and reveal redirect, Public pages smoke › Start page has primary CTA, Designers slug redirects › therapist redirects to start with guide, Designers slug redirects › mae redirects to start with guide, Designers slug redirects › naturalist redirects to start with guide, Intake flow › designer selection, chat progression, and reveal redirect, Public pages smoke › Start page has primary CTA)*
- `npx playwright test e2e/intake-flow.pw.ts` *(fails: Intake flow › designer selection, chat progression, and reveal redirect)*

------
https://chatgpt.com/codex/tasks/task_e_689b66ad34ac832294bb758cbc3301bd