### PR TITLE
Link designer cards directly to intake preferences

### DIFF
--- a/components/DesignerCard.tsx
+++ b/components/DesignerCard.tsx
@@ -9,7 +9,7 @@ export default function DesignerCard({ d }: { d: DesignerProfile }) {
       <div className="text-lg font-semibold">{d.name}</div>
       <div className="text-neutral-600">{d.tagline}</div>
       <div className="text-neutral-500 text-sm mt-2">{d.style}</div>
-      <Link href={`/start?designer=${d.id}`} className="inline-block mt-4 rounded-xl px-4 py-2 bg-black text-white">
+      <Link href={`/preferences/${d.id}`} className="inline-block mt-4 rounded-xl px-4 py-2 bg-black text-white">
         Choose {d.name.split(' ')[0]}
       </Link>
     </motion.div>


### PR DESCRIPTION
## Summary
- Link each `DesignerCard` directly to `/preferences/:id` so choosing a designer jumps straight into intake

## Testing
- `npm test` *(fails: use-intake-chat, Cinematic reveal)*
- `npx playwright test e2e/intake-flow.pw.ts` *(interrupted: page.goto("/designers") error)*

------
https://chatgpt.com/codex/tasks/task_e_689b6e959f648322a0c3e16363ffaad7