### PR TITLE
Allow therapist designer id

### DIFF
--- a/types/colorStory.ts
+++ b/types/colorStory.ts
@@ -4,16 +4,18 @@ export type PaletteColor = {
   brand: string;
   placement: string;
 };
+export type DesignerId = 'emily' | 'zane' | 'marisol' | 'therapist';
+
 export type ColorStory = {
   id: string;
   title: string;
   narrative: string;
   palette: PaletteColor[];
-  designer: 'emily' | 'zane' | 'marisol';
+  designer: DesignerId;
   createdAt: string;
 };
 export type DesignerProfile = {
-  id: 'emily' | 'zane' | 'marisol';
+  id: DesignerId;
   name: string;
   tagline: string;
   style: string;


### PR DESCRIPTION
## Summary
- allow 'therapist' designer id by defining shared DesignerId type
- reuse new DesignerId in ColorStory and DesignerProfile types

## Testing
- `npm test` *(fails: Cinematic reveal > renders and exits on Esc)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689b760c94948322bc0bed64ed41b7c0