### PR TITLE
Support resume after sign-in

### DIFF
--- a/e2e/intake-flow.pw.ts
+++ b/e2e/intake-flow.pw.ts
@@ -21,4 +21,40 @@ test.describe("Intake flow", () => {
     await expect(page).toHaveURL(/\/intake$/)
     await expect(page.getByText("Which room?")).toBeVisible()
   })
+
+  test("unauthenticated reveal round-trips through sign-in", async ({ page }) => {
+    await page.route("**/api/chat", route =>
+      route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({
+          field_id: "_complete",
+          next_question: "Ready?",
+          input_type: "text"
+        })
+      })
+    )
+
+    let call = 0
+    await page.route("**/api/stories", route => {
+      call++
+      if (call === 1) {
+        route.fulfill({ status: 401, contentType: "application/json", body: "{}" })
+      } else {
+        route.fulfill({ status: 200, contentType: "application/json", body: JSON.stringify({ id: "story-123" }) })
+      }
+    })
+
+    await page.goto("/intake")
+    await page.getByRole("button", { name: /reveal my palette/i }).click()
+
+    await expect(page).toHaveURL(/\/sign-in\?next=%2Fintake%3Fresume%3Dreveal/)
+
+    await page.evaluate(() => {
+      const p = new URLSearchParams(window.location.search)
+      window.location.href = p.get("next")!
+    })
+
+    await expect(page).toHaveURL(/\/reveal\/story-123/)
+  })
 })


### PR DESCRIPTION
## Summary
- Preserve intake session and resume reveal after authentication
- Thread `next` parameter through sign-in flows
- Test unauthenticated reveal redirects through sign-in

## Testing
- `npm test`
- `npm run test:e2e e2e/intake-flow.pw.ts` *(fails: browserType.launch: Executable doesn't exist at /root/.cache/ms-playwright/...)*

------
https://chatgpt.com/codex/tasks/task_e_689b8c9e36bc8322ac94e39410fc1d20