### PR TITLE
fix: improve subtext contrast on dark backgrounds

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -68,6 +68,11 @@ a, button, [role="button"] { outline-offset: 3px; }
   --secondary-foreground: 210 16% 92%;
   --accent-foreground: 0 0% 100%;
   }
+  /* Apply light subtext to the moss theme as it's a dark surface */
+  .theme-moss {
+    --muted-foreground: 213 27% 84%;
+    --subtext-on-dark: 213 27% 84%;
+  }
 }
 
 /* Strong, visible focus for keyboard users */


### PR DESCRIPTION
## Summary
- apply light muted-foreground color to `theme-moss` for better legibility on dark green surfaces

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689b8c76039483228b58f0575e7f4a13