### PR TITLE
Align intake flow with simplified question set

### DIFF
--- a/db/migrations/2025-08-11_api-intake.sql
+++ b/db/migrations/2025-08-11_api-intake.sql
@@ -40,10 +40,15 @@ create table if not exists palette_guidelines (
 -- Seed active flow + guidelines if none exist
 insert into intake_flows (slug, version, is_active, nodes)
 select 'default', 1, true, '{
-  "start": { "id":"start", "type":"single", "key":"brand", "question":"Which paint brand do you prefer?", "options":["Sherwin-Williams","Behr"], "next":"lighting" },
-  "lighting": { "id":"lighting", "type":"single", "key":"lighting", "question":"How is the light in the room?", "options":["Low","Mixed","Bright"], "next":"vibe" },
-  "vibe": { "id":"vibe", "type":"multi", "key":"vibe", "question":"Pick a couple words that match your vibe", "options":["Cozy","Calm","Elegant","Airy","Bold"], "min":1, "max":2, "next":"room" },
-  "room": { "id":"room", "type":"single", "key":"room", "question":"What space is this for?", "options":["Living Room","Bedroom","Kitchen","Office"], "next":"done" },
+  "start": { "id":"start", "type":"single", "key":"room_type", "question":"Which room?", "options":["Foyer","Living","Dining","Kitchen","Pantry","Breakfast Nook","Bedroom","Kid's Room","Nursery","Home Office","Bathroom","Powder Room","Laundry/Mudroom","Hallway","Stairwell","Loft/Bonus","Media Room","Sunroom","Basement","Gym","Closet","Garage","Other"], "next":"primary_use" },
+  "primary_use": { "id":"primary_use", "type":"multi", "key":"primary_use", "question":"Top uses (pick up to 3)", "options":["Relax","Work/Study","Entertain","Sleep","Play","Eat","Cook","Get ready","Laundry","Storage","Exercise","Other"], "max":3, "next":"desired_vibe" },
+  "desired_vibe": { "id":"desired_vibe", "type":"single", "key":"desired_vibe", "question":"Desired vibe", "options":["Calm","Airy","Cozy","Focused","Luxe","Energizing","Grounded","Fresh","Moody"], "next":"avoid_vibe" },
+  "avoid_vibe": { "id":"avoid_vibe", "type":"single", "key":"avoid_vibe", "question":"Vibe you do NOT want", "next":"lighting" },
+  "lighting": { "id":"lighting", "type":"single", "key":"lighting", "question":"How is the lighting? (e.g., lots of daylight, warm artificial light)", "next":"room_photos" },
+  "room_photos": { "id":"room_photos", "type":"multi", "key":"room_photos", "question":"Room photos (8am/noon/4pm; lights off + on)", "helper":"Daylight near a window; include one shot with white paper for reference.", "next":"existing_elements_desc" },
+  "existing_elements_desc": { "id":"existing_elements_desc", "type":"single", "key":"existing_elements_desc", "question":"Describe key existing items (optional)", "next":"existing_elements_photos" },
+  "existing_elements_photos": { "id":"existing_elements_photos", "type":"multi", "key":"existing_elements_photos", "question":"Photos of existing items", "next":"adjacent_photos" },
+  "adjacent_photos": { "id":"adjacent_photos", "type":"multi", "key":"adjacent_photos", "question":"Photos of adjacent rooms/sightlines", "next":"done" },
   "done": { "id":"done", "type":"end" }
 }'::jsonb
 where not exists (select 1 from intake_flows where is_active = true);

--- a/tests/api/intakes.test.ts
+++ b/tests/api/intakes.test.ts
@@ -2,8 +2,15 @@ import { describe, it, expect, vi } from "vitest"
 
 vi.mock("@supabase/supabase-js", () => {
   const flow = { slug:"default", version:1, nodes: {
-    start:{ id:"start", type:"single", key:"brand", question:"Brand?", options:["Sherwin-Williams","Behr"], next:"lighting" },
-    lighting:{ id:"lighting", type:"single", key:"lighting", question:"Light?", options:["Low","Mixed","Bright"], next:"done" },
+    start:{ id:"start", type:"single", key:"room_type", question:"Which room?", options:["Foyer","Living","Dining","Kitchen","Pantry","Breakfast Nook","Bedroom","Kid's Room","Nursery","Home Office","Bathroom","Powder Room","Laundry/Mudroom","Hallway","Stairwell","Loft/Bonus","Media Room","Sunroom","Basement","Gym","Closet","Garage","Other"], next:"primary_use" },
+    primary_use:{ id:"primary_use", type:"multi", key:"primary_use", question:"Top uses (pick up to 3)", options:["Relax","Work/Study","Entertain","Sleep","Play","Eat","Cook","Get ready","Laundry","Storage","Exercise","Other"], max:3, next:"desired_vibe" },
+    desired_vibe:{ id:"desired_vibe", type:"single", key:"desired_vibe", question:"Desired vibe", options:["Calm","Airy","Cozy","Focused","Luxe","Energizing","Grounded","Fresh","Moody"], next:"avoid_vibe" },
+    avoid_vibe:{ id:"avoid_vibe", type:"single", key:"avoid_vibe", question:"Vibe you do NOT want", next:"lighting" },
+    lighting:{ id:"lighting", type:"single", key:"lighting", question:"How is the lighting? (e.g., lots of daylight, warm artificial light)", next:"room_photos" },
+    room_photos:{ id:"room_photos", type:"multi", key:"room_photos", question:"Room photos (8am/noon/4pm; lights off + on)", helper:"Daylight near a window; include one shot with white paper for reference.", next:"existing_elements_desc" },
+    existing_elements_desc:{ id:"existing_elements_desc", type:"single", key:"existing_elements_desc", question:"Describe key existing items (optional)", next:"existing_elements_photos" },
+    existing_elements_photos:{ id:"existing_elements_photos", type:"multi", key:"existing_elements_photos", question:"Photos of existing items", next:"adjacent_photos" },
+    adjacent_photos:{ id:"adjacent_photos", type:"multi", key:"adjacent_photos", question:"Photos of adjacent rooms/sightlines", next:"done" },
     done:{ id:"done", type:"end" }
   }}
   let session:any = null
@@ -32,9 +39,9 @@ describe("intakes API", () => {
     const start = await import("@/app/api/intakes/start/route")
     const r1 = await start.POST(new Request("http://x", { method:"POST", body: JSON.stringify({ designerId:"therapist" }) }) as any)
     const j1 = await (r1 as Response).json()
-    expect(j1.sessionId).toBeTruthy()
+    expect(j1.step.node.question).toBe("Which room?")
     const step = await import("@/app/api/intakes/step/route")
-    const r2 = await step.POST(new Request("http://x", { method:"POST", body: JSON.stringify({ sessionId: j1.sessionId, answer:"Behr" }) }) as any)
+    const r2 = await step.POST(new Request("http://x", { method:"POST", body: JSON.stringify({ sessionId: j1.sessionId, answer:"Living" }) }) as any)
     const j2 = await (r2 as Response).json()
     expect(j2.step.type).toBe("question")
   })


### PR DESCRIPTION
## Summary
- sync active intake flow nodes with simplified questions from `intake-graph`
- remove obsolete brand/vibe questions and consolidate lighting & upload prompts
- update API test to reflect new flow

## Testing
- `npm test tests/api/intakes.test.ts`
- Verified `/api/intakes/start` returns first question "Which room?"

------
https://chatgpt.com/codex/tasks/task_e_689b908b86748322b4b4e5397b7ddf0f