### PR TITLE
Direct Start color story to designers page

### DIFF
--- a/app/(shell)/home/page.tsx
+++ b/app/(shell)/home/page.tsx
@@ -9,7 +9,7 @@ export default function HomeShell(){
   <p className="text-sm text-muted-foreground max-w-md">Three quick steps: pick a designer, share a few preferences, preview your palette.</p>
       </header>
       <div className="space-y-6">
-        <Link href="/start" className="btn btn-primary w-full sm:w-auto">Start color story</Link>
+        <Link href="/designers" className="btn btn-primary w-full sm:w-auto">Start color story</Link>
         <div className="grid gap-4 sm:grid-cols-2">
           <Link href="/discover" className="card p-6 hover:shadow-md transition-shadow"><h2 className="font-semibold mb-2">Discover color stories</h2><p className="text-sm text-muted-foreground">Explore recent palettes & reveals.</p></Link>
           <Link href="/designers" className="card p-6 hover:shadow-md transition-shadow"><h2 className="font-semibold mb-2">Meet our designers</h2><p className="text-sm text-muted-foreground">Choose a style lens to guide your picks.</p></Link>


### PR DESCRIPTION
## Summary
- Link the "Start color story" button on the home page directly to `/designers` instead of the old `/start` route

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689b9114ba7c83229927bdef8b80c4bb