### PR TITLE
Handle 'Not sure' answers during intake finalization

### DIFF
--- a/app/api/intakes/finalize/route.ts
+++ b/app/api/intakes/finalize/route.ts
@@ -7,14 +7,36 @@ export async function POST(req: Request) {
   const { sessionId } = await req.json()
   if (!sessionId) return NextResponse.json({ error:"session_required" }, { status: 400 })
   const supa = createClient(process.env.NEXT_PUBLIC_SUPABASE_URL!, process.env.SUPABASE_SERVICE_ROLE_KEY!)
-  const { data: session } = await supa.from("intake_sessions").select("*").eq("id", sessionId).single()
-  const { data: guideline } = await supa.from("palette_guidelines").select("config,designer_id,brand").eq("is_active", true).maybeSingle()
+  const { data: session } = await supa
+    .from("intake_sessions")
+    .select("*")
+    .eq("id", sessionId)
+    .single()
+  const { data: guideline } = await supa
+    .from("palette_guidelines")
+    .select("config,designer_id,brand")
+    .eq("is_active", true)
+    .maybeSingle()
+
+  const clean = (v: any) => {
+    if (v === undefined || v === null) return undefined
+    if (typeof v === "string" && /not sure/i.test(v)) return undefined
+    return v
+  }
+
+  const answers = session.answers || {}
+  const vibeRaw = clean(answers.vibe)
+  const vibe = Array.isArray(vibeRaw)
+    ? vibeRaw.filter((x: any) => typeof x === "string" && !/not sure/i.test(x))
+    : typeof vibeRaw === "string"
+    ? [vibeRaw]
+    : []
 
   const input = {
-    brand: session.answers.brand ?? (guideline?.brand || "Sherwin-Williams"),
-    lighting: session.answers.lighting ?? "Mixed",
-    vibe: session.answers.vibe ?? [],
-    space: session.answers.room ?? "Living Room",
+    brand: clean(answers.brand) ?? guideline?.brand ?? "Sherwin-Williams",
+    lighting: clean(answers.lighting) ?? "Mixed",
+    vibe,
+    space: clean(answers.room) ?? "Living Room",
     contrast: guideline?.config?.contrast ?? "balanced",
     seed: `sess:${session.id}`
   }

--- a/tests/api/intakes-finalize.test.ts
+++ b/tests/api/intakes-finalize.test.ts
@@ -1,0 +1,39 @@
+import { describe, it, expect, vi } from 'vitest'
+
+vi.mock('@supabase/supabase-js', () => {
+  const session = { id: 'sess-1', answers: { brand: 'Not sure', lighting: 'Not sure', vibe: 'Not sure', room: 'Not sure' } }
+  const guideline = { config: { contrast: 'balanced' }, designer_id: 'd1', brand: 'Sherwin-Williams' }
+  return {
+    createClient: () => ({
+      from: (table: string) => ({
+        select: () => ({
+          eq: () => ({
+            single: async () => ({ data: table === 'intake_sessions' ? session : null, error: null }),
+            maybeSingle: async () => ({ data: table === 'palette_guidelines' ? guideline : null, error: null })
+          })
+        })
+      })
+    })
+  }
+})
+
+vi.mock('@/lib/ai/orchestrator', () => ({
+  designPalette: vi.fn(async () => ({ swatches: [], placements: { primary: 60, secondary: 30, accent: 10, trim: 5, ceiling: 5 } }))
+}))
+
+import { POST } from '@/app/api/intakes/finalize/route'
+
+describe('intakes finalize', () => {
+  it('handles "Not sure" answers gracefully', async () => {
+    const res = await POST(new Request('http://x', { method: 'POST', body: JSON.stringify({ sessionId: 'sess-1' }) }))
+    const data = await res.json()
+    expect(data.input).toEqual({
+      brand: 'Sherwin-Williams',
+      lighting: 'Mixed',
+      vibe: [],
+      space: 'Living Room',
+      contrast: 'balanced',
+      seed: 'sess:sess-1'
+    })
+  })
+})


### PR DESCRIPTION
## Summary
- Strip "Not sure" answers before building AI design input so defaults are used
- Add test ensuring finalize route cleans skipped answers

## Testing
- `npm test tests/api/intakes-finalize.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_689b846d549083229381b7eabe2e1436