### PR TITLE
feat: deterministic intake questionnaire

### DIFF
--- a/components/assistant/QuestionRenderer.tsx
+++ b/components/assistant/QuestionRenderer.tsx
@@ -1,6 +1,8 @@
 "use client";
 import React from "react";
 import type { IntakeTurn } from "@/lib/types";
+import { track } from "@/lib/analytics";
+import { getQuestionPriority } from "@/lib/intake/questions";
 
 type Props = {
   turn: IntakeTurn | null;
@@ -15,6 +17,11 @@ export default function QuestionRenderer({ turn, onAnswer, onComplete, completeB
   const [text, setText] = React.useState("");
 
   if (!turn) return null;
+
+  React.useEffect(() => {
+    if (!turn || !turn.field_id || turn.field_id === "_complete") return;
+    track('question_shown', { id: turn.field_id, priority: getQuestionPriority(turn.field_id) });
+  }, [turn?.field_id]);
 
   if (turn.field_id === "_complete") {
     return (
@@ -37,6 +44,9 @@ export default function QuestionRenderer({ turn, onAnswer, onComplete, completeB
   }
 
   const send = (val: string) => {
+    if (turn.field_id) {
+      track('answer_saved', { id: turn.field_id, priority: getQuestionPriority(turn.field_id) });
+    }
     onAnswer(val);
     setText("");
   };

--- a/lib/analytics/events.ts
+++ b/lib/analytics/events.ts
@@ -14,6 +14,10 @@ export interface AnalyticsEventMap {
   explanation_copy: { len: number }
   explanation_listen: { len: number }
   variant_open: { id: string; variant: string }
+  question_shown: { id: string; priority: 'P1' | 'P2' | 'P3' | 'P4' }
+  answer_saved: { id: string; priority: 'P1' | 'P2' | 'P3' | 'P4' }
+  question_dropped: { id: string; priority: 'P1' | 'P2' | 'P3' | 'P4'; reason: string }
+  flow_capped: { id: string; priority: 'P1' | 'P2' | 'P3' | 'P4'; reason: string }
 }
 
 export type AnalyticsEventName = keyof AnalyticsEventMap

--- a/lib/intake/engine.ts
+++ b/lib/intake/engine.ts
@@ -37,3 +37,97 @@ export function nextStep(flow: unknown, state: EngineState, nodeId: string, rawA
   if (!nextId || nodes[nextId]?.type === "end") return { type:"done" }
   return { type:"question", node: nodes[nextId] }
 }
+
+// ---------- Deterministic Questionnaire Engine ----------
+import type { Answers, QuestionId, Priority } from './types'
+import { QUESTIONS, getQuestionPriority } from './questions'
+import { track } from '@/lib/analytics'
+
+const HARD_CAP = 15
+const DROP_ORDER: QuestionId[] = [
+  'k_fixed_details',
+  'b_fixed_details',
+  'l_fixed_details',
+  'o_coordination_preference',
+  'dark_locations',
+  'window_aspect',
+  'h_adjacent_color',
+]
+
+function push(queue: QuestionId[], id: QuestionId) {
+  if (!QUESTIONS[id]) return
+  queue.push(id)
+}
+
+export function enforceCap(queue: QuestionId[]): QuestionId[] {
+  if (queue.length <= HARD_CAP) return queue
+  const dropped: { id: QuestionId; priority: Priority }[] = []
+  for (const id of DROP_ORDER) {
+    if (queue.length <= HARD_CAP) break
+    const idx = queue.indexOf(id)
+    if (idx >= 0) {
+      const [d] = queue.splice(idx, 1)
+      dropped.push({ id: d, priority: getQuestionPriority(d) })
+      track('question_dropped', { id: d, priority: getQuestionPriority(d), reason: 'cap' })
+    }
+  }
+  while (queue.length > HARD_CAP) {
+    const d = queue.pop() as QuestionId
+    dropped.push({ id: d, priority: getQuestionPriority(d) })
+    track('question_dropped', { id: d, priority: getQuestionPriority(d), reason: 'cap' })
+  }
+  if (dropped.length) {
+    track('flow_capped', { id: dropped[0].id, priority: dropped[0].priority, reason: 'cap' })
+  }
+  return queue
+}
+
+export function buildQuestionQueue(answers: Answers): QuestionId[] {
+  const q: QuestionId[] = []
+  push(q, 'room_type')
+  push(q, 'mood_words')
+  push(q, 'style_primary')
+  push(q, 'light_level')
+  if (answers.light_level === 'varies') push(q, 'window_aspect')
+  push(q, 'dark_stance')
+  if (answers.dark_stance && answers.dark_stance !== 'avoid') push(q, 'dark_locations')
+
+  switch (answers.room_type) {
+    case 'kitchen':
+      push(q, 'k_fixed_elements')
+      if ((answers.fixed_elements?.filter(e => ['ctops','backsplash','cabinets','flooring','appliances'].includes(e)).length || 0) >= 2 && !answers.fixed_elements?.includes('none'))
+        push(q, 'k_fixed_details')
+      break
+    case 'bathroom':
+      push(q, 'b_fixed_elements')
+      if ((answers.fixed_elements?.filter(e => ['vanity_top','tile','fixtures_finish','bath_flooring'].includes(e)).length || 0) >= 2 && !answers.fixed_elements?.includes('none'))
+        push(q, 'b_fixed_details')
+      break
+    case 'nursery':
+    case 'bedroom_kid':
+      push(q, 'n_theme_keepers')
+      break
+    case 'hallway_entry':
+      push(q, 'h_flow_targets')
+      if (answers.flow_targets && answers.flow_targets.length > 0) push(q, 'h_adjacent_color')
+      break
+    case 'open_concept':
+      push(q, 'o_anchors_keep')
+      push(q, 'l_anchors_keep')
+      if ((answers.fixed_elements?.filter(e => ['wood_floor','fireplace','builtins_trim','major_furniture','rugs_textiles','artwork'].includes(e)).length || 0) >= 2 && !answers.fixed_elements?.includes('none'))
+        push(q, 'l_fixed_details')
+      push(q, 'o_coordination_preference')
+      break
+    default:
+      if (['living_room','dining','bedroom_adult','home_office'].includes(answers.room_type as string)) {
+        push(q, 'l_anchors_keep')
+        if ((answers.fixed_elements?.filter(e => ['wood_floor','fireplace','builtins_trim','major_furniture','rugs_textiles','artwork'].includes(e)).length || 0) >= 2 && !answers.fixed_elements?.includes('none'))
+          push(q, 'l_fixed_details')
+      }
+  }
+
+  push(q, 'constraints')
+  if (answers.constraints?.includes('color_rules')) push(q, 'avoid_colors')
+
+  return enforceCap(q)
+}

--- a/lib/intake/questions.ts
+++ b/lib/intake/questions.ts
@@ -1,0 +1,193 @@
+import type { QuestionId, Priority, Answers } from './types';
+
+export type InputKind = 'single' | 'multi' | 'text' | 'chipText' | 'photo';
+
+export interface Question {
+  id: QuestionId;
+  field: keyof Answers | null;
+  text: string;
+  type: InputKind;
+  options?: string[];
+  priority: Priority;
+  required?: boolean;
+  condition?: (a: Answers) => boolean;
+}
+
+export const QUESTIONS: Record<QuestionId, Question> = {
+  room_type: {
+    id: 'room_type',
+    field: 'room_type',
+    text: 'Which space are we designing?',
+    type: 'single',
+    options: ['living_room','kitchen','bedroom_adult','bedroom_kid','nursery','bathroom','dining','home_office','hallway_entry','open_concept'],
+    priority: 'P1',
+    required: true,
+  },
+  mood_words: {
+    id: 'mood_words',
+    field: 'mood_words',
+    text: 'In three words, how should this room feel?',
+    type: 'chipText',
+    priority: 'P1',
+    required: true,
+  },
+  style_primary: {
+    id: 'style_primary',
+    field: 'style_primary',
+    text: 'Which style resonates most?',
+    type: 'single',
+    options: ['Modern Minimalist','Organic Cottage','Moody Traditional','Japandi','Scandinavian','Industrial','Bohemian','Coastal','Mid-Century','Transitional','Not sure / Mix'],
+    priority: 'P1',
+    required: true,
+  },
+  light_level: {
+    id: 'light_level',
+    field: 'light_level',
+    text: 'How would you describe the natural light?',
+    type: 'single',
+    options: ['bright','moderate','low','varies'],
+    priority: 'P1',
+    required: true,
+  },
+  window_aspect: {
+    id: 'window_aspect',
+    field: 'window_aspect',
+    text: 'Which direction do your main windows face?',
+    type: 'single',
+    options: ['north','south','east','west','multiple','unknown'],
+    priority: 'P3',
+    condition: a => a.light_level === 'varies',
+  },
+  dark_stance: {
+    id: 'dark_stance',
+    field: 'dark_stance',
+    text: 'How do you feel about darker/bolder colors?',
+    type: 'single',
+    options: ['walls','accents','avoid','open'],
+    priority: 'P1',
+    required: true,
+  },
+  dark_locations: {
+    id: 'dark_locations',
+    field: 'dark_locations',
+    text: 'Where might you want darker/bolder colors?',
+    type: 'multi',
+    options: ['all_walls','accent_wall','ceiling','trim_doors','cabinetry','designer_suggest'],
+    priority: 'P3',
+    condition: a => a.dark_stance !== 'avoid' && !!a.dark_stance,
+  },
+  k_fixed_elements: {
+    id: 'k_fixed_elements',
+    field: 'fixed_elements',
+    text: 'What fixed elements need to coordinate with your paint?',
+    type: 'multi',
+    options: ['ctops','backsplash','cabinets','flooring','appliances','none'],
+    priority: 'P1',
+    condition: a => a.room_type === 'kitchen',
+  },
+  k_fixed_details: {
+    id: 'k_fixed_details',
+    field: 'fixed_details',
+    text: 'Quick details on your main fixed elements',
+    type: 'text',
+    priority: 'P4',
+    condition: a => a.room_type === 'kitchen' && (a.fixed_elements?.filter(e => ['ctops','backsplash','cabinets','flooring','appliances'].includes(e)).length || 0) >= 2 && !a.fixed_elements?.includes('none'),
+  },
+  b_fixed_elements: {
+    id: 'b_fixed_elements',
+    field: 'fixed_elements',
+    text: 'What fixed elements need to coordinate with your paint?',
+    type: 'multi',
+    options: ['vanity_top','tile','fixtures_finish','bath_flooring','none'],
+    priority: 'P1',
+    condition: a => a.room_type === 'bathroom',
+  },
+  b_fixed_details: {
+    id: 'b_fixed_details',
+    field: 'fixed_details',
+    text: 'Quick details on your main fixed elements',
+    type: 'text',
+    priority: 'P4',
+    condition: a => a.room_type === 'bathroom' && (a.fixed_elements?.filter(e => ['vanity_top','tile','fixtures_finish','bath_flooring'].includes(e)).length || 0) >= 2 && !a.fixed_elements?.includes('none'),
+  },
+  l_anchors_keep: {
+    id: 'l_anchors_keep',
+    field: 'fixed_elements',
+    text: 'Anchors & keepers to coordinate?',
+    type: 'multi',
+    options: ['wood_floor','fireplace','builtins_trim','major_furniture','rugs_textiles','artwork','none'],
+    priority: 'P1',
+    condition: a => ['living_room','dining','bedroom_adult','home_office','open_concept'].includes(a.room_type||''),
+  },
+  l_fixed_details: {
+    id: 'l_fixed_details',
+    field: 'fixed_details',
+    text: 'Quick details on your main fixed elements',
+    type: 'text',
+    priority: 'P4',
+    condition: a => ['living_room','dining','bedroom_adult','home_office','open_concept'].includes(a.room_type||'') && (a.fixed_elements?.filter(e => ['wood_floor','fireplace','builtins_trim','major_furniture','rugs_textiles','artwork'].includes(e)).length || 0) >= 2 && !a.fixed_elements?.includes('none'),
+  },
+  n_theme_keepers: {
+    id: 'n_theme_keepers',
+    field: 'theme',
+    text: 'Any theme or existing pieces?',
+    type: 'text',
+    priority: 'P1',
+    condition: a => a.room_type === 'nursery' || a.room_type === 'bedroom_kid',
+  },
+  h_flow_targets: {
+    id: 'h_flow_targets',
+    field: 'flow_targets',
+    text: 'Which adjacent spaces should this coordinate with?',
+    type: 'multi',
+    priority: 'P1',
+    condition: a => a.room_type === 'hallway_entry',
+  },
+  h_adjacent_color: {
+    id: 'h_adjacent_color',
+    field: 'adjacent_primary_color',
+    text: 'Primary color of adjacent space?',
+    type: 'chipText',
+    priority: 'P3',
+    condition: a => a.room_type === 'hallway_entry' && !!(a.flow_targets && a.flow_targets.length > 0),
+  },
+  o_anchors_keep: {
+    id: 'o_anchors_keep',
+    field: 'anchors_keep',
+    text: 'Is there a non-paint visual anchor we should respect?',
+    type: 'multi',
+    options: ['dark_floor','stone','metal','large_sofa_rug','none'],
+    priority: 'P1',
+    condition: a => a.room_type === 'open_concept',
+  },
+  o_coordination_preference: {
+    id: 'o_coordination_preference',
+    field: null,
+    text: 'One cohesive palette vs subtle zone shifts?',
+    type: 'single',
+    options: ['One cohesive','Subtle zone shifts','Not sure'],
+    priority: 'P4',
+    condition: a => a.room_type === 'open_concept',
+  },
+  constraints: {
+    id: 'constraints',
+    field: 'constraints',
+    text: 'Any special considerations?',
+    type: 'multi',
+    options: ['kids_pets','renting','hoa','low_voc','color_rules','budget','none'],
+    priority: 'P2',
+    required: true,
+  },
+  avoid_colors: {
+    id: 'avoid_colors',
+    field: 'avoid_colors',
+    text: 'What colors should we avoid?',
+    type: 'chipText',
+    priority: 'P3',
+    condition: a => a.constraints?.includes('color_rules') || false,
+  },
+};
+
+export function getQuestionPriority(id: string): Priority {
+  return QUESTIONS[id as QuestionId]?.priority || 'P4';
+}

--- a/lib/intake/types.ts
+++ b/lib/intake/types.ts
@@ -1,0 +1,61 @@
+export type RoomType =
+  | 'living_room' | 'kitchen' | 'bedroom_adult' | 'bedroom_kid' | 'nursery'
+  | 'bathroom' | 'dining' | 'home_office' | 'hallway_entry' | 'open_concept';
+
+export type LightLevel = 'bright' | 'moderate' | 'low' | 'varies';
+export type WindowAspect = 'north' | 'south' | 'east' | 'west' | 'multiple' | 'unknown';
+export type DarkStance = 'walls' | 'accents' | 'avoid' | 'open';
+
+export type ConstraintKey = 'kids_pets' | 'renting' | 'hoa' | 'low_voc' | 'color_rules' | 'budget';
+export type DarkLocation = 'all_walls' | 'accent_wall' | 'ceiling' | 'trim_doors' | 'cabinetry' | 'designer_suggest';
+
+export type FixedElement =
+  | 'ctops' | 'backsplash' | 'cabinets' | 'flooring' | 'appliances'
+  | 'vanity_top' | 'tile' | 'fixtures_finish' | 'bath_flooring'
+  | 'wood_floor' | 'fireplace' | 'builtins_trim' | 'major_furniture' | 'rugs_textiles' | 'artwork';
+
+export type AnchorOpenConcept = 'dark_floor' | 'stone' | 'metal' | 'large_sofa_rug' | 'none';
+
+export interface Answers {
+  room_type?: RoomType;
+  mood_words?: string[];          // up to 3
+  style_primary?: string;         // from list or 'mix'
+  light_level?: LightLevel;
+  window_aspect?: WindowAspect;   // only if varies
+  dark_stance?: DarkStance;
+  dark_locations?: DarkLocation[]; // if stance != 'avoid'
+  fixed_elements?: FixedElement[]; // room-specific
+  fixed_details?: Record<string, string>; // key per element: material/tone/undertone/color
+  anchors_keep?: AnchorOpenConcept[]; // open concept
+  flow_targets?: string[];        // hallway adjacency labels
+  adjacent_primary_color?: string;
+  theme?: string;                 // nursery/kids
+  keepers?: string[];             // nursery/kids (crib/rug/etc.)
+  constraints?: ConstraintKey[];
+  avoid_colors?: string[];        // if color_rules
+  uploads?: string[];             // file ids/urls; never counted as a question
+}
+
+export type Priority = 'P1' | 'P2' | 'P3' | 'P4';
+
+export type QuestionId =
+  | 'room_type'
+  | 'mood_words'
+  | 'style_primary'
+  | 'light_level'
+  | 'window_aspect'
+  | 'dark_stance'
+  | 'dark_locations'
+  | 'k_fixed_elements'
+  | 'k_fixed_details'
+  | 'b_fixed_elements'
+  | 'b_fixed_details'
+  | 'l_anchors_keep'
+  | 'l_fixed_details'
+  | 'n_theme_keepers'
+  | 'h_flow_targets'
+  | 'h_adjacent_color'
+  | 'o_anchors_keep'
+  | 'o_coordination_preference'
+  | 'constraints'
+  | 'avoid_colors';

--- a/tests/intake/question-queue.test.ts
+++ b/tests/intake/question-queue.test.ts
@@ -1,0 +1,70 @@
+import { describe, it, expect, vi } from 'vitest'
+import { buildQuestionQueue, enforceCap } from '@/lib/intake/engine'
+import type { Answers } from '@/lib/intake/types'
+import { track } from '@/lib/analytics'
+
+vi.mock('@/lib/analytics', () => ({ track: vi.fn() }))
+
+describe('buildQuestionQueue', () => {
+  it('nursery shortest path', () => {
+    const q = buildQuestionQueue({ room_type: 'nursery' })
+    expect(q).toEqual([
+      'room_type','mood_words','style_primary','light_level','dark_stance','n_theme_keepers','constraints'
+    ])
+  })
+
+  it('kitchen medium path', () => {
+    const answers: Answers = {
+      room_type: 'kitchen',
+      light_level: 'varies',
+      dark_stance: 'walls',
+      fixed_elements: ['ctops','backsplash']
+    }
+    const q = buildQuestionQueue(answers)
+    expect(q).toEqual([
+      'room_type','mood_words','style_primary','light_level','window_aspect','dark_stance','dark_locations','k_fixed_elements','k_fixed_details','constraints'
+    ])
+  })
+
+  it('hallway path', () => {
+    const q = buildQuestionQueue({ room_type: 'hallway_entry', flow_targets: ['kitchen'] })
+    expect(q).toEqual([
+      'room_type','mood_words','style_primary','light_level','dark_stance','h_flow_targets','h_adjacent_color','constraints'
+    ])
+  })
+
+  it('open concept long path', () => {
+    const answers: Answers = {
+      room_type: 'open_concept',
+      light_level: 'varies',
+      dark_stance: 'walls',
+      fixed_elements: ['wood_floor','fireplace'],
+      constraints: ['color_rules']
+    }
+    const q = buildQuestionQueue(answers)
+    expect(q).toEqual([
+      'room_type','mood_words','style_primary','light_level','window_aspect','dark_stance','dark_locations','o_anchors_keep','l_anchors_keep','l_fixed_details','o_coordination_preference','constraints','avoid_colors'
+    ])
+    expect(q.length).toBeLessThanOrEqual(15)
+  })
+
+  it('enforces hard cap drop order', () => {
+    vi.clearAllMocks()
+    const queue = [
+      'room_type','mood_words','style_primary','light_level','dark_stance',
+      'k_fixed_elements','b_fixed_elements','l_anchors_keep','h_flow_targets','constraints',
+      'avoid_colors','o_anchors_keep','n_theme_keepers','k_fixed_elements','b_fixed_elements',
+      'k_fixed_details','b_fixed_details','l_fixed_details','o_coordination_preference','dark_locations','window_aspect','h_adjacent_color'
+    ]
+    const capped = enforceCap([...queue])
+    expect(capped.length).toBeLessThanOrEqual(15)
+    const order = (track as unknown as vi.Mock).mock.calls
+      .filter(c => c[0] === 'question_dropped')
+      .map(c => c[1].id)
+    expect(order).toEqual([
+      'k_fixed_details','b_fixed_details','l_fixed_details','o_coordination_preference','dark_locations','window_aspect','h_adjacent_color'
+    ])
+    const flow = (track as unknown as vi.Mock).mock.calls.find(c => c[0] === 'flow_capped')
+    expect(flow).toBeTruthy()
+  })
+})


### PR DESCRIPTION
## Summary
- define structured room-intake types and question catalog with priorities and conditions
- add deterministic intake engine that builds capped question queue with drop-order instrumentation
- track question_shown and answer_saved analytics events

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689ba3d680dc83228631a43cc6295dc8