### PR TITLE
Fix conditional hook and expand FixedElement type

### DIFF
--- a/components/assistant/QuestionRenderer.tsx
+++ b/components/assistant/QuestionRenderer.tsx
@@ -15,15 +15,16 @@ type Props = {
 
 export default function QuestionRenderer({ turn, onAnswer, onComplete, completeBusy }: Props) {
   const [text, setText] = React.useState("");
+  const fieldId = turn?.field_id;
+
+  React.useEffect(() => {
+    if (!fieldId || fieldId === "_complete") return;
+    track('question_shown', { id: fieldId, priority: getQuestionPriority(fieldId) });
+  }, [fieldId]);
 
   if (!turn) return null;
 
-  React.useEffect(() => {
-    if (!turn || !turn.field_id || turn.field_id === "_complete") return;
-    track('question_shown', { id: turn.field_id, priority: getQuestionPriority(turn.field_id) });
-  }, [turn?.field_id]);
-
-  if (turn.field_id === "_complete") {
+  if (fieldId === "_complete") {
     return (
       <div className="p-4 rounded-2xl border bg-white/70 dark:bg-neutral-900/70 text-center">
         <div className="text-lg font-medium">{turn.next_question}</div>

--- a/lib/intake/types.ts
+++ b/lib/intake/types.ts
@@ -12,7 +12,8 @@ export type DarkLocation = 'all_walls' | 'accent_wall' | 'ceiling' | 'trim_doors
 export type FixedElement =
   | 'ctops' | 'backsplash' | 'cabinets' | 'flooring' | 'appliances'
   | 'vanity_top' | 'tile' | 'fixtures_finish' | 'bath_flooring'
-  | 'wood_floor' | 'fireplace' | 'builtins_trim' | 'major_furniture' | 'rugs_textiles' | 'artwork';
+  | 'wood_floor' | 'fireplace' | 'builtins_trim' | 'major_furniture' | 'rugs_textiles' | 'artwork'
+  | 'none';
 
 export type AnchorOpenConcept = 'dark_floor' | 'stone' | 'metal' | 'large_sofa_rug' | 'none';
 


### PR DESCRIPTION
## Summary
- ensure QuestionRenderer's tracking effect runs unconditionally and tracks by field id
- allow `FixedElement` answers to include `"none"` to satisfy build

## Testing
- `npm run lint`
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689ba849d19c8322a560ddca6df67f85