### PR TITLE
Fix reveal button click handler

### DIFF
--- a/components/assistant/QuestionRenderer.tsx
+++ b/components/assistant/QuestionRenderer.tsx
@@ -35,7 +35,7 @@ export default function QuestionRenderer({ turn, onAnswer, onComplete, completeB
         {onComplete && (
           <button
             className="btn btn-primary mt-3"
-            onClick={onComplete}
+            onClick={() => onComplete?.()}
             disabled={completeBusy}
           >
             {completeBusy ? "Generating…" : "Reveal My Palette"}


### PR DESCRIPTION
## Summary
- ensure "Reveal My Palette" click handler triggers without receiving an event object

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689bd8929eac8322bc7d6e9524988950