### PR TITLE
fix: make reveal palette button clickable

### DIFF
--- a/components/assistant/QuestionRenderer.tsx
+++ b/components/assistant/QuestionRenderer.tsx
@@ -34,6 +34,7 @@ export default function QuestionRenderer({ turn, onAnswer, onComplete, completeB
         )}
         {onComplete && (
           <button
+            type="button"
             className="btn btn-primary mt-3"
             onClick={() => onComplete?.()}
             disabled={completeBusy}

--- a/tests/ui/intake-complete.test.tsx
+++ b/tests/ui/intake-complete.test.tsx
@@ -19,5 +19,23 @@ describe('QuestionRenderer completion', () => {
     fireEvent.click(btn)
     expect(onComplete).toHaveBeenCalledTimes(1)
   })
+
+  it('renders reveal button as a non-submitting button', () => {
+    const onComplete = vi.fn()
+    const turn = {
+      field_id: '_complete',
+      next_question: 'Ready?',
+      input_type: 'text'
+    } as any
+    render(
+      <form>
+        <QuestionRenderer turn={turn} onAnswer={() => {}} onComplete={onComplete} />
+      </form>
+    )
+    const btn = screen.getByRole('button', { name: /reveal my palette/i })
+    expect(btn).toHaveAttribute('type', 'button')
+    fireEvent.click(btn)
+    expect(onComplete).toHaveBeenCalledTimes(1)
+  })
 })
 


### PR DESCRIPTION
## Summary
- prevent unintended form submission on "Reveal My Palette" button
- verify button type through unit test

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689bdef3848483229a20406800f23720