### PR TITLE
Allow guest palette generation

### DIFF
--- a/app/intake/page.tsx
+++ b/app/intake/page.tsx
@@ -68,12 +68,18 @@ export default function IntakePage() {
           source: "intake"
         })
       });
+      const data = await res.json();
+      if (data?.story) {
+        try { localStorage.setItem("colrvia:lastStory", JSON.stringify(data.story)); } catch {}
+        router.push("/reveal");
+        return;
+      }
       if (res.status === 401) {
+        setRevealing(false);
         try { localStorage.setItem("colrvia_session", JSON.stringify(current)); } catch {}
         router.push(`/sign-in?next=${encodeURIComponent("/intake?resume=reveal")}`);
         return;
       }
-      const data = await res.json();
       if (!res.ok || !data?.id) {
         setError(data?.error || "Could not create story");
         return;

--- a/tests/api/stories-guest.test.ts
+++ b/tests/api/stories-guest.test.ts
@@ -1,0 +1,38 @@
+// tests/api/stories-guest.test.ts
+import { describe, it, expect, vi } from 'vitest'
+import * as storiesRoute from '@/app/api/stories/route'
+
+vi.mock('@/lib/supabase/server', () => ({
+  supabaseServer: () => ({
+    auth: { getUser: async () => ({ data: { user: null }, error: null }) },
+    from: () => ({ insert: () => ({ select: () => ({ single: async () => ({ data: null, error: null }) }) }) })
+  })
+}))
+
+vi.mock('@/lib/ai/palette', () => ({
+  seedPaletteFor: () => [{ brand: 'sherwin_williams', code: 'SW 7005', name: 'Pure White', hex: '#FEFEFE' }],
+}))
+vi.mock('@/lib/ai/orchestrator', () => ({
+  designPalette: () => ({ swatches: [], placements: { primary: 60, secondary: 30, accent: 10, trim: 5, ceiling: 5 } }),
+}))
+vi.mock('@/lib/palette/normalize-repair', () => ({
+  normalizePaletteOrRepair: async () => [
+    { brand: 'sherwin_williams', code: 'SW 7005', name: 'Pure White', hex: '#FEFEFE', role: 'walls' },
+    { brand: 'sherwin_williams', code: 'SW 7008', name: 'Alabaster', hex: '#FFFFFF', role: 'trim' },
+    { brand: 'sherwin_williams', code: 'SW 7036', name: 'Accessible Beige', hex: '#E5D8C8', role: 'cabinets' },
+    { brand: 'sherwin_williams', code: 'SW 7043', name: 'Worldly Gray', hex: '#D8D4CE', role: 'accent' },
+    { brand: 'sherwin_williams', code: 'SW 6204', name: 'Sea Salt', hex: '#CDD8D2', role: 'extra' },
+  ],
+}))
+
+describe('/api/stories guest access', () => {
+  it('returns story when unauthenticated', async () => {
+    const req = new Request('http://localhost/api/stories', { method: 'POST', body: JSON.stringify({ brand: 'sherwin_williams', vibe: 'Cozy Neutral' }) })
+    const res = await storiesRoute.POST(req as any)
+    expect(res.status).toBe(200)
+    const json = await res.json()
+    expect(json.story).toBeDefined()
+    expect(json.story.id).toBeNull()
+    expect(Array.isArray(json.story.palette)).toBe(true)
+  })
+})

--- a/types/api.ts
+++ b/types/api.ts
@@ -5,7 +5,14 @@ export type ApiIssue = { path: string; message: string }
 export type ApiError = { error: string; issues?: ApiIssue[] }
 
 // /api/stories POST
-export type StoriesPostOk = { id: string }
+export type StoryPayload = {
+  id: string | null;
+  title: string;
+  palette: { hex: string; name: string; brand: string; placement: string }[];
+  narrative: string;
+  createdAt: string;
+};
+export type StoriesPostOk = { id: string } | { story: StoryPayload };
 export type StoriesPostRes = StoriesPostOk | ApiError
 
 // /api/stories/[id]/variant POST

--- a/types/colorStory.ts
+++ b/types/colorStory.ts
@@ -7,11 +7,11 @@ export type PaletteColor = {
 export type DesignerId = 'emily' | 'zane' | 'marisol' | 'therapist';
 
 export type ColorStory = {
-  id: string;
+  id: string | null;
   title: string;
   narrative: string;
   palette: PaletteColor[];
-  designer: DesignerId;
+  designer?: DesignerId;
   createdAt: string;
 };
 export type DesignerProfile = {


### PR DESCRIPTION
## Summary
- allow unauthenticated palette generation by returning story data instead of 401
- persist guest stories in localStorage and reset reveal state on auth redirect
- expand API types to support guest stories and add regression test

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689be8ebc9e48322bc41abf5f78ac755