### PR TITLE
Refactor intake form with shared field component

### DIFF
--- a/app/(app)/intake/page.tsx
+++ b/app/(app)/intake/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useForm } from "react-hook-form";
+import { FormProvider, useForm } from "react-hook-form";
 import { z } from "zod";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { useRouter } from "next/navigation";
@@ -8,6 +8,7 @@ import { TemplateChips } from "@/components/intake/TemplateChips";
 import { Progress } from "@/components/intake/Progress";
 import { LivePreview } from "@/components/intake/LivePreview";
 import { StickyCTA } from "@/components/intake/StickyCTA";
+import { FormField } from "@/components/form/FormField";
 // import { track } from "@/lib/analytics"; // if you added it
 
 const IntakeSchema = z.object({
@@ -27,11 +28,12 @@ const TEMPLATES = [
 
 export default function IntakePage() {
   const router = useRouter();
-  const { register, setValue, handleSubmit, formState:{ errors, isSubmitting }, watch, trigger } = useForm<Intake>({
+  const form = useForm<Intake>({
     mode: "onBlur",
     resolver: zodResolver(IntakeSchema),
-    defaultValues: { room: undefined, style: undefined, budget: undefined, prompt: "" } as any
+    defaultValues: { room: undefined, style: undefined, budget: undefined, prompt: "" } as any,
   });
+  const { setValue, handleSubmit, formState: { isSubmitting }, watch } = form;
 
   const selection = { room: watch("room"), style: watch("style") };
 
@@ -57,58 +59,99 @@ export default function IntakePage() {
 
   return (
     <div className="mx-auto max-w-6xl px-4 md:px-6 py-6 md:py-8 grid md:grid-cols-[1fr_340px] gap-6">
-      <form onSubmit={handleSubmit(onSubmit)} aria-describedby="intake-help">
-        <Progress step={1} total={2} />
-        <TemplateChips templates={TEMPLATES} onApply={(v)=>{ Object.entries(v).forEach(([k,val]) => setValue(k as any, val, { shouldValidate:true })); }} />
-
-        {/* Room */}
-        <div className="mb-4">
-          <label htmlFor="room" className="text-sm font-medium">Room</label>
-          <select id="room" {...register("room")} onBlur={()=>trigger("room")}
-            className="mt-1 w-full rounded-xl border px-3 py-2"
-            aria-invalid={!!errors.room} aria-describedby="room-help"
-          >
-            <option value="" hidden>Select a room</option>
-            {["Living room","Bedroom","Kitchen","Bathroom","Workspace"].map(r=> <option key={r} value={r}>{r}</option>)}
-          </select>
-          <p id="room-help" className="mt-1 text-xs text-neutral-500">{errors.room?.message ?? "Pick the space you’re redesigning."}</p>
-        </div>
-
-        {/* Style */}
-        <div className="mb-4">
-          <label htmlFor="style" className="text-sm font-medium">Style</label>
-          <select id="style" {...register("style")} onBlur={()=>trigger("style")}
-            className="mt-1 w-full rounded-xl border px-3 py-2"
-            aria-invalid={!!errors.style} aria-describedby="style-help"
-          >
-            <option value="" hidden>Select a style</option>
-            {["Modern","Cozy","Minimalist","Mid-century","Scandinavian"].map(s=> <option key={s} value={s}>{s}</option>)}
-          </select>
-          <p id="style-help" className="mt-1 text-xs text-neutral-500">{errors.style?.message ?? "We’ll tailor layouts, textures, and finishes."}</p>
-        </div>
-
-        {/* Prompt */}
-        <div className="mb-6">
-          <label htmlFor="prompt" className="text-sm font-medium">Describe your space</label>
-          <textarea id="prompt" rows={4} {...register("prompt")} onBlur={()=>trigger("prompt")}
-            placeholder="Natural light, wood accents, neutral palette…"
-            className="mt-1 w-full rounded-xl border px-3 py-2"
-            aria-invalid={!!errors.prompt} aria-describedby="prompt-help"
+      <FormProvider {...form}>
+        <form onSubmit={handleSubmit(onSubmit)} aria-describedby="intake-help">
+          <Progress step={1} total={2} />
+          <TemplateChips
+            templates={TEMPLATES}
+            onApply={(v) => {
+              Object.entries(v).forEach(([k, val]) =>
+                setValue(k as any, val, { shouldValidate: true })
+              );
+            }}
           />
-          <p id="prompt-help" className="mt-1 text-xs text-neutral-500">{errors.prompt?.message ?? "Add key constraints and preferences."}</p>
-        </div>
 
-        {/* Desktop primary action */}
-        <div className="hidden md:flex items-center gap-3">
-          <button type="submit" disabled={isSubmitting} className="rounded-xl px-4 py-3 bg-brand text-brand-contrast hover:bg-brand-hover disabled:opacity-50">
-            Generate (≈12s)
-          </button>
-          <span className="text-xs text-neutral-500">Private to you · You can edit inputs later</span>
-        </div>
+          {/* Room */}
+          <div className="mb-4">
+            <FormField name="room" label="Room" hint="Pick the space you’re redesigning.">
+              {({ id, error, field }) => (
+                <select
+                  id={id}
+                  {...field}
+                  className="w-full rounded-xl border px-3 py-2"
+                  aria-invalid={!!error}
+                  aria-describedby={`${id}-hint`}
+                >
+                  <option value="" hidden>
+                    Select a room
+                  </option>
+                  {["Living room", "Bedroom", "Kitchen", "Bathroom", "Workspace"].map((r) => (
+                    <option key={r} value={r}>
+                      {r}
+                    </option>
+                  ))}
+                </select>
+              )}
+            </FormField>
+          </div>
 
-        {/* Mobile sticky CTA */}
-        <StickyCTA disabled={isSubmitting} />
-      </form>
+          {/* Style */}
+          <div className="mb-4">
+            <FormField name="style" label="Style" hint="We’ll tailor layouts, textures, and finishes.">
+              {({ id, error, field }) => (
+                <select
+                  id={id}
+                  {...field}
+                  className="w-full rounded-xl border px-3 py-2"
+                  aria-invalid={!!error}
+                  aria-describedby={`${id}-hint`}
+                >
+                  <option value="" hidden>
+                    Select a style
+                  </option>
+                  {["Modern", "Cozy", "Minimalist", "Mid-century", "Scandinavian"].map((s) => (
+                    <option key={s} value={s}>
+                      {s}
+                    </option>
+                  ))}
+                </select>
+              )}
+            </FormField>
+          </div>
+
+          {/* Prompt */}
+          <div className="mb-6">
+            <FormField name="prompt" label="Describe your space" hint="Add key constraints and preferences.">
+              {({ id, error, field }) => (
+                <textarea
+                  id={id}
+                  rows={4}
+                  {...field}
+                  placeholder="Natural light, wood accents, neutral palette…"
+                  className="w-full rounded-xl border px-3 py-2"
+                  aria-invalid={!!error}
+                  aria-describedby={`${id}-hint`}
+                />
+              )}
+            </FormField>
+          </div>
+
+          {/* Desktop primary action */}
+          <div className="hidden md:flex items-center gap-3">
+            <button
+              type="submit"
+              disabled={isSubmitting}
+              className="rounded-xl px-4 py-3 bg-brand text-brand-contrast hover:bg-brand-hover disabled:opacity-50"
+            >
+              Generate (≈12s)
+            </button>
+            <span className="text-xs text-neutral-500">Private to you · You can edit inputs later</span>
+          </div>
+
+          {/* Mobile sticky CTA */}
+          <StickyCTA disabled={isSubmitting} />
+        </form>
+      </FormProvider>
 
       {/* Right rail preview (desktop) */}
       <div className="hidden md:block">


### PR DESCRIPTION
## Summary
- refactor intake page to wrap form in FormProvider
- use shared FormField component for room, style, and prompt inputs

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689c1ef708108322b77392cd5b93ece0