### PR TITLE
Improve accessibility and brand styling

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -2,8 +2,9 @@
 module.exports = {
   root: true,
   extends: ["next/core-web-vitals"],
-  plugins: ["jsx-a11y"],
+  plugins: ["jsx-a11y", "react"],
   rules: {
+    "react/button-has-type": "warn",
     "jsx-a11y/no-noninteractive-element-interactions": "warn",
     "jsx-a11y/click-events-have-key-events": "warn",
     "jsx-a11y/anchor-is-valid": "warn"

--- a/__tests__/layout/theme-moss-applied.test.tsx
+++ b/__tests__/layout/theme-moss-applied.test.tsx
@@ -25,7 +25,7 @@ describe("Root layout applies moss theme globally", () => {
     // @ts-ignore invoking async server component for test
   const element = await RootLayout({ children: <div>child</div> })
     const html = renderToStaticMarkup(element as any)
-    expect(html).toContain('class="theme-moss"')
+    expect(html).toContain('theme-moss')
     expect(html).toContain('bg-[var(--color-bg)]')
     expect(html).toContain('text-[var(--color-fg)]')
   })

--- a/app/(app)/dashboard/new-project-form.tsx
+++ b/app/(app)/dashboard/new-project-form.tsx
@@ -28,16 +28,24 @@ export default function NewProjectForm() {
   }
 
   return (
-    <form onSubmit={onSubmit} className="space-y-3">
+    <form onSubmit={onSubmit} aria-describedby="np-help" className="space-y-3">
+      <label htmlFor="project-name" className="text-sm text-neutral-700">
+        Project name
+      </label>
       <input
+        id="project-name"
         type="text"
-        placeholder="New project name"
+        placeholder="e.g., Living room refresh"
         value={name}
         onChange={e => setName(e.target.value)}
         className="w-full rounded-xl border px-3 py-2"
         disabled={loading}
         required
+        aria-describedby="np-help"
       />
+      <p id="np-help" className="mt-1 text-xs text-neutral-500">
+        You can rename this later.
+      </p>
       <button
         type="submit"
         disabled={loading}

--- a/app/(app)/offline/retry-client.tsx
+++ b/app/(app)/offline/retry-client.tsx
@@ -2,6 +2,6 @@
 
 export default function OfflineRetry(){
   return (
-    <button onClick={()=>window.location.reload()} className="btn btn-primary">Try again</button>
+    <button type="button" onClick={()=>window.location.reload()} className="btn btn-primary">Try again</button>
   );
 }

--- a/app/(shell)/more/page.tsx
+++ b/app/(shell)/more/page.tsx
@@ -46,7 +46,7 @@ export default function MorePage(){
         ))}
         <li>
           {session ? (
-            <button onClick={logout} className="w-full text-left px-5 py-4 hover:bg-[var(--linen)]/60">Log out</button>
+            <button type="button" onClick={logout} className="w-full text-left px-5 py-4 hover:bg-[var(--linen)]/60">Log out</button>
           ) : (
             <Link href="/sign-in" className="w-full block text-left px-5 py-4 hover:bg-[var(--linen)]/60">Log in</Link>
           )}

--- a/app/(shell)/reveal/[id]/actions-client.tsx
+++ b/app/(shell)/reveal/[id]/actions-client.tsx
@@ -17,8 +17,8 @@ export default function ActionsClient({ storyId, palette }: ActionsProps){
   }
   return (
     <div className="flex gap-3 pt-4 flex-wrap">
-      <button onClick={copyAll} className="btn btn-primary">Copy all codes</button>
-      <button onClick={openShare} className="btn btn-secondary">Share Image</button>
+      <button type="button" onClick={copyAll} className="btn btn-primary">Copy all codes</button>
+      <button type="button" onClick={openShare} className="btn btn-secondary">Share Image</button>
     </div>
   )
 }

--- a/app/(shell)/reveal/[id]/reveal-client.tsx
+++ b/app/(shell)/reveal/[id]/reveal-client.tsx
@@ -6,7 +6,7 @@ export default function RevealClient({ story }:{ story:{ id:string; title:string
   const [open,setOpen]=useState(false)
   return (
     <>
-      <button onClick={()=>setOpen(true)} className="btn btn-secondary text-xs">Play Reveal</button>
+      <button type="button" onClick={()=>setOpen(true)} className="btn btn-secondary text-xs">Play Reveal</button>
       <Cinematic open={open} onExit={()=>setOpen(false)} story={story} />
     </>
   )

--- a/app/account/reduced-motion-toggle.tsx
+++ b/app/account/reduced-motion-toggle.tsx
@@ -4,7 +4,7 @@ import { useMotion } from '@/components/theme/MotionSettings'
 export default function ReducedMotionToggle(){
   const { reduced, toggle } = useMotion()
   return (
-    <button onClick={toggle} className="text-sm px-3 py-1.5 rounded border bg-white/50 hover:bg-white transition">
+    <button type="button" onClick={toggle} className="text-sm px-3 py-1.5 rounded border bg-white/50 hover:bg-white transition">
       {reduced ? 'Reduced motion enabled' : 'Enable reduced motion'}
     </button>
   )

--- a/app/auth/callback/page.tsx
+++ b/app/auth/callback/page.tsx
@@ -40,7 +40,7 @@ function Inner(){
   return (
   <div className="min-h-screen flex items-center justify-center text-sm text-muted-foreground">
       {status==='working' && <div>Signing you in…</div>}
-      {status==='error' && <div>Sign-in failed. <button onClick={()=>router.replace('/sign-in')} className="underline">Return to sign-in</button></div>}
+      {status==='error' && <div>Sign-in failed. <button type="button" onClick={()=>router.replace('/sign-in')} className="underline">Return to sign-in</button></div>}
       {status==='done' && <div>Redirecting…</div>}
     </div>
   )

--- a/app/error.tsx
+++ b/app/error.tsx
@@ -25,7 +25,7 @@ export default function GlobalError({
           </p>
 
           <div className="flex items-center justify-center gap-3">
-            <button
+            <button type="button"
               onClick={() => reset()}
               className="inline-flex items-center justify-center rounded-2xl px-4 py-2 border border-border focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-[var(--ring)] ring-offset-[var(--surface)]"
             >

--- a/app/first-run/welcome/page.tsx
+++ b/app/first-run/welcome/page.tsx
@@ -15,7 +15,7 @@ export default function FirstRunWelcome(){
         <div className="space-y-3">
           <Link href="/designers" onClick={setDone} className="btn btn-primary w-full">Start color story</Link>
           <Link href="/sign-in" onClick={()=>{ setDone(); }} className="btn btn-secondary w-full">Sign in</Link>
-          <button onClick={()=>{ setDone(); router.push('/home') }} className="btn btn-ghost w-full">Skip for now</button>
+          <button type="button" onClick={()=>{ setDone(); router.push('/home') }} className="btn btn-ghost w-full">Skip for now</button>
         </div>
       </div>
     </main>

--- a/app/globals.css
+++ b/app/globals.css
@@ -1,6 +1,5 @@
 @import "tailwindcss";
 @import '../styles/tokens.css';
-@import '../styles/local-fonts.css';
 
 /* Tokens sourced from styles/tokens.css now. */
 

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -16,8 +16,16 @@ import AmbientEdge from '@/components/ui/ambient-edge'
 import dynamic from 'next/dynamic'
 import { NextIntlClientProvider, createTranslator } from 'next-intl'
 import { getLocale, getMessages } from '@/lib/i18n'
+import { Inter as InterFont, Fraunces as FrauncesFont } from 'next/font/google'
 
 initSentry()
+
+const inter = typeof InterFont === 'function'
+  ? InterFont({ subsets: ['latin'], display: 'swap', variable: '--font-inter' })
+  : { variable: '--font-inter' }
+const fraunces = typeof FrauncesFont === 'function'
+  ? FrauncesFont({ subsets: ['latin'], display: 'swap', variable: '--font-fraunces' })
+  : { variable: '--font-fraunces' }
 
 const RouteTransition = dynamic(() => import('@/components/ux/RouteTransition'), { ssr:false })
 const StartStoryPortalProvider = dynamic(()=> import('@/components/ux/StartStoryPortal').then(m=> m.StartStoryPortalProvider), { ssr:false })
@@ -65,10 +73,11 @@ export default async function RootLayout({
   const t = createTranslator({ locale, messages })
 
   return (
-    <html lang={locale} className="theme-moss">
+    <html lang={locale} className={`${inter.variable} ${fraunces.variable} theme-moss`}>
       <head>
         <meta name="theme-color" content="#F7F5EF" />
         <meta name="theme-color" media="(prefers-color-scheme: dark)" content="#121212" />
+        <meta name="color-scheme" content="light dark" />
       </head>
       <body
         className={cn(

--- a/app/sign-in/page.tsx
+++ b/app/sign-in/page.tsx
@@ -124,8 +124,8 @@ export default function SignInPage() {
       <div className="text-sm tracking-widest font-medium mb-6">{t('brand')}</div>
       <h1 className="text-2xl font-semibold mb-2">{mode==='magic' ? t('titleSignIn') : (pwPhase==='signin'? t('titleSignIn') : t('titleCreate'))}</h1>
       <div className="flex gap-3 mb-6 text-sm" role="tablist">
-        <button role="tab" aria-selected={mode==='magic'} onClick={()=>{ setMode('magic'); setMsg(null) }} className={`px-3 py-1 rounded-full border ${mode==='magic'?'bg-black text-white':'bg-white'}`}>{t('magicLinkTab')}</button>
-        <button role="tab" aria-selected={mode==='password'} onClick={()=>{ setMode('password'); setMsg(null) }} className={`px-3 py-1 rounded-full border ${mode==='password'?'bg-black text-white':'bg-white'}`}>{t('passwordTab')}</button>
+        <button type="button" role="tab" aria-selected={mode==='magic'} onClick={()=>{ setMode('magic'); setMsg(null) }} className={`px-3 py-1 rounded-full border ${mode==='magic'?'bg-black text-white':'bg-white'}`}>{t('magicLinkTab')}</button>
+        <button type="button" role="tab" aria-selected={mode==='password'} onClick={()=>{ setMode('password'); setMsg(null) }} className={`px-3 py-1 rounded-full border ${mode==='password'?'bg-black text-white':'bg-white'}`}>{t('passwordTab')}</button>
       </div>
 
       {mode==='magic' && (
@@ -175,7 +175,7 @@ export default function SignInPage() {
         <div className="h-px flex-1 bg-neutral-200" />
       </div>
 
-      <button onClick={continueWithGoogle} disabled={busy} className="w-full rounded-2xl py-3 border">{t('continueWithGoogle')}</button>
+      <button type="button" onClick={continueWithGoogle} disabled={busy} className="w-full rounded-2xl py-3 border">{t('continueWithGoogle')}</button>
 
       {msg && <p className="mt-4 text-sm text-neutral-700 whitespace-pre-line">{msg}</p>}
       <p className="mt-2 text-xs text-neutral-400">{t('redirectOrigin', { origin })}</p>

--- a/components/AppShell.tsx
+++ b/components/AppShell.tsx
@@ -10,9 +10,13 @@ export default function AppShell({ children }: { children: React.ReactNode }) {
         <div className="max-w-content container flex items-center justify-between py-3">
           <Link href="/" className="font-display text-2xl">Colrvia</Link>
           <nav aria-label="Utility" className="flex gap-3">
-            <Link href="/account" aria-label="Account" className="rounded-full border border-white/15 bg-white/5 p-2 hover:bg-white/10 transition-colors">
+            <Link
+              href="/account"
+              aria-label="Account"
+              className="relative inline-flex rounded-full border border-white/15 bg-white/5 p-2 hover:bg-white/10 transition-colors"
+            >
+              <span className="absolute inset-[-6px]" aria-hidden />
               <User className="h-5 w-5" />
-              <span className="sr-only">Account</span>
             </Link>
           </nav>
         </div>

--- a/components/RevealActions.tsx
+++ b/components/RevealActions.tsx
@@ -18,7 +18,7 @@ export function RevealActions({ storyId, tier }: { storyId:string; tier:'free'|'
   }
   return (
     <div className="flex gap-3 pt-4">
-      <button onClick={download} className="btn btn-secondary" disabled={downloading}>{downloading?'Creating…':'Download PDF'}</button>
+      <button type="button" onClick={download} className="btn btn-secondary" disabled={downloading}>{downloading?'Creating…':'Download PDF'}</button>
       <PaywallModal open={open} onClose={()=>setOpen(false)} />
     </div>
   )

--- a/components/SaveStoryToProject.tsx
+++ b/components/SaveStoryToProject.tsx
@@ -112,7 +112,7 @@ export default function SaveStoryToProject() {
             </select>
           )}
           <div className="flex items-center gap-3">
-            <button onClick={save} disabled={!story || !selected || saving} className="rounded-xl px-4 py-2 bg-black text-white disabled:opacity-50 text-sm">
+            <button type="button" onClick={save} disabled={!story || !selected || saving} className="rounded-xl px-4 py-2 bg-black text-white disabled:opacity-50 text-sm">
               {saving ? 'Saving…' : 'Save'}
             </button>
             <button onClick={createProject} type="button" className="text-sm underline">+ New project</button>

--- a/components/StoryReveal.tsx
+++ b/components/StoryReveal.tsx
@@ -20,7 +20,7 @@ function Swatch({ c }: { c: PaletteColor }) {
         <div className="text-neutral-600">{c.hex} · {c.brand}</div>
         <div className="text-neutral-500 mt-1 text-xs">{c.placement}</div>
       </div>
-      <button
+      <button type="button"
         aria-label={`Copy ${c.hex}`}
         onClick={() => { navigator.clipboard.writeText(c.hex); setCopied(true); setTimeout(()=>setCopied(false), 1000) }}
         className="absolute top-2 right-2 text-[10px] px-2 py-1 rounded-md bg-black/70 text-white opacity-0 group-hover:opacity-100 transition"

--- a/components/ai/DesignersCarousel.tsx
+++ b/components/ai/DesignersCarousel.tsx
@@ -22,7 +22,7 @@ function useReducedMotionPref() {
 }
 
 export default function DesignersCarousel(){
-  const listRef = useRef<HTMLDivElement|null>(null)
+  const listRef = useRef<HTMLUListElement|null>(null)
   const reduced = useReducedMotionPref()
   const id = 'designers-carousel'
   const [active, setActive] = useState(0)
@@ -64,19 +64,40 @@ export default function DesignersCarousel(){
       <div className="pointer-events-none absolute inset-y-0 left-0 w-10 bg-gradient-to-r from-[var(--bg-canvas)] to-transparent z-10" />
       <div className="pointer-events-none absolute inset-y-0 right-0 w-10 bg-gradient-to-l from-[var(--bg-canvas)] to-transparent z-10" />
       <div className="absolute inset-y-0 left-0 z-20 flex items-center">
-  <button type="button" className="btn btn-secondary rounded-full shadow-sm h-10 w-10" aria-controls={id} aria-label="Previous" onClick={()=>scrollByDir(-1)}>
+        <button
+          type="button"
+          className="btn btn-secondary relative rounded-full shadow-sm h-10 w-10"
+          aria-controls={id}
+          aria-label="Previous"
+          onClick={() => scrollByDir(-1)}
+        >
+          <span className="absolute inset-[-4px]" aria-hidden />
           <ChevronLeft className="h-5 w-5" />
         </button>
       </div>
       <div className="absolute inset-y-0 right-0 z-20 flex items-center">
-  <button type="button" className="btn btn-secondary rounded-full shadow-sm h-10 w-10" aria-controls={id} aria-label="Next" onClick={()=>scrollByDir(1)}>
+        <button
+          type="button"
+          className="btn btn-secondary relative rounded-full shadow-sm h-10 w-10"
+          aria-controls={id}
+          aria-label="Next"
+          onClick={() => scrollByDir(1)}
+        >
+          <span className="absolute inset-[-4px]" aria-hidden />
           <ChevronRight className="h-5 w-5" />
         </button>
       </div>
-      <div id={id} ref={listRef} className="no-scrollbar flex gap-4 overflow-x-auto pb-2 snap-x snap-mandatory scroll-pl-4 -mx-4 px-4">
+      <div aria-live="polite" className="sr-only">{`Showing ${designers[active].name}`}</div>
+      <ul
+        id={id}
+        ref={listRef}
+        role="list"
+        aria-label="Designer styles"
+        className="no-scrollbar flex gap-4 overflow-x-auto pb-2 snap-x snap-mandatory scroll-pl-4 -mx-4 px-4"
+      >
         {designers.map((d, idx)=>{
           return (
-            <div key={d.id} className="snap-center relative min-w-[85%] md:min-w-[480px] lg:min-w-[540px]" data-card-index={idx}>
+            <li key={d.id} className="snap-center relative min-w-[85%] md:min-w-[480px] lg:min-w-[540px]" data-card-index={idx}>
               <motion.div initial={reduced? false : { opacity:0, y:10, scale:0.98 }} whileInView={reduced? {} : { opacity:1, y:0, scale:1 }} viewport={{ once:true, amount:0.6 }} transition={{ duration:0.28 }} className="rounded-3xl overflow-hidden border bg-[var(--bg-surface)] shadow-sm">
                 <div className="relative h-[420px] md:h-[480px]">
                   <Image src={d.heroImage} alt="" fill sizes="(max-width: 768px) 85vw, 540px" priority={idx===0} className="object-cover" />
@@ -101,10 +122,10 @@ export default function DesignersCarousel(){
                   <div className="absolute right-4 top-4 h-8 w-8 rounded-lg bg-[var(--bg-surface)]/60 backdrop-blur-sm border" aria-hidden />
                 </div>
               </motion.div>
-            </div>
+            </li>
           )
         })}
-      </div>
+      </ul>
 
     <div className="mt-4 flex items-center justify-center gap-2" aria-label="Slide position">
         {designers.map((_,i)=>(

--- a/components/ai/OnboardingChat.tsx
+++ b/components/ai/OnboardingChat.tsx
@@ -21,7 +21,7 @@ export default function OnboardingChat({ designerId }: { designerId: string }) {
       {Array.isArray(currentNode?.options) && currentNode.options.length > 0 && !done && (
         <div className="mt-3 flex flex-wrap gap-2">
           {currentNode.options.map((o: string) => (
-            <button
+            <button type="button"
               key={o}
               disabled={busy}
               onClick={() => submit(o)}
@@ -44,7 +44,7 @@ export default function OnboardingChat({ designerId }: { designerId: string }) {
             placeholder="Say it or type it…"
             className="flex-1 rounded-xl bg-white/10 px-3 py-2 text-sm outline-none placeholder:text-white/60"
           />
-          <button
+          <button type="button"
             onClick={() => submit(input)}
             disabled={!input || busy}
             className="rounded-xl bg-white/20 px-3 py-2 text-sm hover:bg-white/25 disabled:opacity-50"

--- a/components/assistant/QuestionRenderer.tsx
+++ b/components/assistant/QuestionRenderer.tsx
@@ -61,11 +61,11 @@ export default function QuestionRenderer({ turn, onAnswer, onComplete, completeB
         return (
           <div className="flex flex-wrap gap-2 mt-3">
             {turn.choices?.map((c) => (
-              <button key={c} className="px-3 py-2 rounded-lg border" onClick={() => send(c)}>
+              <button type="button" key={c} className="px-3 py-2 rounded-lg border" onClick={() => send(c)}>
                 {c}
               </button>
             ))}
-            <button className="px-3 py-2 rounded-lg border opacity-80" onClick={() => send("Not sure")}>
+            <button type="button" className="px-3 py-2 rounded-lg border opacity-80" onClick={() => send("Not sure")}>
               I’m not sure
             </button>
           </div>
@@ -77,7 +77,7 @@ export default function QuestionRenderer({ turn, onAnswer, onComplete, completeB
               {turn.choices?.map((c) => {
                 const active = selected.includes(c);
                 return (
-                  <button
+                  <button type="button"
                     key={c}
                     className={`px-3 py-2 rounded-lg border ${active ? 'bg-neutral-200' : ''}`}
                     onClick={() => {
@@ -92,14 +92,14 @@ export default function QuestionRenderer({ turn, onAnswer, onComplete, completeB
               })}
             </div>
             <div className="flex gap-2 mt-3">
-              <button
+              <button type="button"
                 className="px-3 py-2 rounded-lg border"
                 onClick={() => send(selected)}
                 disabled={selected.length === 0}
               >
                 Continue
               </button>
-              <button
+              <button type="button"
                 className="px-3 py-2 rounded-lg border opacity-80"
                 onClick={() => send("Not sure")}
               >
@@ -111,9 +111,9 @@ export default function QuestionRenderer({ turn, onAnswer, onComplete, completeB
       case "yesNo":
         return (
           <div className="flex gap-2 mt-3">
-            <button className="px-3 py-2 rounded-lg border" onClick={() => send("Yes")}>Yes</button>
-            <button className="px-3 py-2 rounded-lg border" onClick={() => send("No")}>No</button>
-            <button className="px-3 py-2 rounded-lg border opacity-80" onClick={() => send("Not sure")}>I’m not sure</button>
+            <button type="button" className="px-3 py-2 rounded-lg border" onClick={() => send("Yes")}>Yes</button>
+            <button type="button" className="px-3 py-2 rounded-lg border" onClick={() => send("No")}>No</button>
+            <button type="button" className="px-3 py-2 rounded-lg border opacity-80" onClick={() => send("Not sure")}>I’m not sure</button>
           </div>
         );
       case "slider":
@@ -129,8 +129,8 @@ export default function QuestionRenderer({ turn, onAnswer, onComplete, completeB
               className="w-full"
             />
             <div className="mt-2 flex gap-2">
-              <button className="px-3 py-2 rounded-lg border" onClick={() => send(text || String(turn.validation?.min ?? 0))}>Continue</button>
-              <button className="px-3 py-2 rounded-lg border opacity-80" onClick={() => send("Not sure")}>Skip / I’m not sure</button>
+              <button type="button" className="px-3 py-2 rounded-lg border" onClick={() => send(text || String(turn.validation?.min ?? 0))}>Continue</button>
+              <button type="button" className="px-3 py-2 rounded-lg border opacity-80" onClick={() => send("Not sure")}>Skip / I’m not sure</button>
             </div>
           </div>
         );

--- a/components/assistant/VoiceMic.tsx
+++ b/components/assistant/VoiceMic.tsx
@@ -124,11 +124,13 @@ export default function VoiceMic({ onActiveChange, greet }: Props) {
   }
 
   return (
-    <div className="flex items-center gap-3">
+    <div className="flex items-center gap-3" aria-busy={active || undefined}>
       <button
+        type="button"
         onClick={active ? stop : start}
         className={`px-4 py-2 rounded-full border ${active ? "bg-black text-white dark:bg-white dark:text-black" : "bg-white/70 dark:bg-neutral-900/70"}`}
         aria-pressed={active}
+        aria-keyshortcuts="Shift+M"
       >
         {active ? "Stop voice" : "Talk to designer"}
       </button>

--- a/components/auth-buttons.tsx
+++ b/components/auth-buttons.tsx
@@ -25,13 +25,13 @@ export function AuthButtons() {
 
   return (
     <div className="flex gap-3">
-      <button
+      <button type="button"
         onClick={signIn}
         className="rounded-xl px-4 py-2 bg-black text-white"
       >
         Sign in
       </button>
-      <button
+      <button type="button"
         onClick={signOut}
         className="rounded-xl px-4 py-2 border"
       >

--- a/components/nav/AccountIcon.tsx
+++ b/components/nav/AccountIcon.tsx
@@ -7,9 +7,15 @@ import { track } from '@/lib/analytics'
 
 export default function AccountIcon(){
   return (
-    <motion.div whileTap={{ scale:0.95 }}>
-  <Link href="/account" className="block" onClick={()=> track('nav_click',{ dest:'/account' })} aria-label="Account">
-  <div className="rounded-full border bg-[var(--bg-surface)]/80 p-2 backdrop-blur hover:bg-[var(--linen)]/70 transition-colors">
+    <motion.div whileTap={{ scale: 0.95 }}>
+      <Link
+        href="/account"
+        aria-label="Account"
+        className="relative inline-flex"
+        onClick={() => track('nav_click', { dest: '/account' })}
+      >
+        <span className="absolute inset-[-6px]" aria-hidden />
+        <div className="rounded-full border bg-[var(--bg-surface)]/80 p-2 backdrop-blur hover:bg-[var(--linen)]/70 transition-colors">
           <User className="h-5 w-5 text-muted-foreground" />
         </div>
       </Link>

--- a/components/nav/TabBar.tsx
+++ b/components/nav/TabBar.tsx
@@ -21,11 +21,14 @@ export default function TabBar(){
           const Icon = t.icon
           return (
             <li key={t.href}>
-              <Link href={t.href} className="flex flex-col items-center text-[11px] font-medium relative px-2 py-1 focus:outline-none focus-visible:underline">
+              <Link
+                href={t.href}
+                aria-current={active ? 'page' : undefined}
+                className="flex flex-col items-center text-[11px] font-medium relative px-2 py-1 focus:outline-none focus-visible:underline"
+              >
                 <Icon size={20} className="mb-0.5" />
                 {t.label}
                 {active && <span aria-hidden className="absolute -bottom-1 w-1.5 h-1.5 rounded-full bg-[var(--brand)]" />}
-                <span className="sr-only">{active? '(Current)': ''}</span>
               </Link>
             </li>
           )

--- a/components/paywall/PaywallModal.tsx
+++ b/components/paywall/PaywallModal.tsx
@@ -29,8 +29,8 @@ export function PaywallModal({ open, onClose }: { open:boolean; onClose:()=>void
           <li>Priority features</li>
         </ul>
         <div className="flex gap-3 pt-2">
-          <button onClick={onClose} className="btn btn-secondary flex-1">Close</button>
-          <button onClick={upgrade} disabled={busy} className="btn btn-primary flex-1">{busy?'Redirect…':'Upgrade to Pro'}</button>
+          <button type="button" onClick={onClose} className="btn btn-secondary flex-1">Close</button>
+          <button type="button" onClick={upgrade} disabled={busy} className="btn btn-primary flex-1">{busy?'Redirect…':'Upgrade to Pro'}</button>
         </div>
         <p className="text-[11px] text-neutral-500">Secure Stripe checkout. Test mode.</p>
       </div>

--- a/components/paywall/UpgradeButton.tsx
+++ b/components/paywall/UpgradeButton.tsx
@@ -22,7 +22,7 @@ export function UpgradeButton({ className }: { className?: string }) {
     }
   }
   return (
-    <button onClick={go} disabled={busy} className={className || 'btn btn-primary'}>
+    <button type="button" onClick={go} disabled={busy} className={className || 'btn btn-primary'}>
       {busy ? 'Redirecting…' : 'Upgrade to Pro'}
     </button>
   )

--- a/components/pwa/InstallPrompt.tsx
+++ b/components/pwa/InstallPrompt.tsx
@@ -21,8 +21,8 @@ export default function InstallPrompt(){
   return (
     <div className="fixed bottom-4 left-4 bg-neutral-900 text-white text-sm px-4 py-3 rounded shadow-lg flex items-center gap-3">
       <span>Install Colrvia?</span>
-      <button className="underline" onClick={async()=>{ if(deferred){ deferred.prompt(); const choice = await deferred.userChoice; } setVisible(false)}}>Install</button>
-      <button aria-label="Dismiss" onClick={()=>{ localStorage.setItem('installDismissedAt', Date.now().toString()); setVisible(false)}} className="opacity-70 hover:opacity-100">×</button>
+      <button type="button" className="underline" onClick={async()=>{ if(deferred){ deferred.prompt(); const choice = await deferred.userChoice; } setVisible(false)}}>Install</button>
+      <button type="button" aria-label="Dismiss" onClick={()=>{ localStorage.setItem('installDismissedAt', Date.now().toString()); setVisible(false)}} className="opacity-70 hover:opacity-100">×</button>
     </div>
   )
 }

--- a/components/reveal/Cinematic.tsx
+++ b/components/reveal/Cinematic.tsx
@@ -92,7 +92,7 @@ export default function Cinematic({ open, onExit, story }: CinematicProps){
                     </motion.div>
                   </Dialog.Description>
                   <div className="flex gap-4 pt-4">
-                    <button
+                    <button type="button"
                       autoFocus
                       onClick={end}
                       className="px-5 py-2 rounded-full bg-white text-neutral-900 text-sm font-medium hover:bg-neutral-200 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-white active:scale-[.97] transition-transform"

--- a/components/reveal/StoryActionBar.tsx
+++ b/components/reveal/StoryActionBar.tsx
@@ -18,8 +18,8 @@ export default function StoryActionBar({ storyId, palette }: ActionBarProps){
   }
   return (
     <div className="flex gap-3 pt-6 flex-wrap">
-  <button onClick={copyAll} className="btn btn-primary">Copy palette codes</button>
-  <button onClick={openShare} className="btn btn-secondary">Open share image</button>
+  <button type="button" onClick={copyAll} className="btn btn-primary">Copy palette codes</button>
+  <button type="button" onClick={openShare} className="btn btn-secondary">Open share image</button>
     </div>
   )
 }

--- a/components/reveal/SwatchCard.tsx
+++ b/components/reveal/SwatchCard.tsx
@@ -49,7 +49,7 @@ export default function SwatchCard({ color, onCopy, index=0, total=0 }: Props){
       role="group"
       aria-label={`${color.name} ${color.hex} ${color.role}`}
       className="group relative rounded-3xl border border-[var(--border)] bg-[var(--bg-surface)] overflow-hidden shadow-sm focus:outline-none focus:ring-2 focus:ring-[var(--brand)]">
-  <button onClick={copy} aria-label={`Copy ${color.name} ${color.hex}`} className="absolute top-2 right-2 z-10 px-2 py-1 rounded-full text-[10px] font-medium bg-[var(--bg-surface)]/85 backdrop-blur border border-[var(--border)] opacity-0 group-hover:opacity-100 transition-[opacity,background-color] duration-200 ease-[var(--motion-ease-standard)] focus-visible:opacity-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--brand)] active:scale-[.97]">{copied? 'Copied':'Copy'}</button>
+  <button type="button" onClick={copy} aria-label={`Copy ${color.name} ${color.hex}`} className="absolute top-2 right-2 z-10 px-2 py-1 rounded-full text-[10px] font-medium bg-[var(--bg-surface)]/85 backdrop-blur border border-[var(--border)] opacity-0 group-hover:opacity-100 transition-[opacity,background-color] duration-200 ease-[var(--motion-ease-standard)] focus-visible:opacity-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--brand)] active:scale-[.97]">{copied? 'Copied':'Copy'}</button>
       <div className="h-32 w-full" style={{ backgroundColor: color.hex }} />
       <div className="p-4">
   <div className="font-medium text-sm flex items-center gap-2"><span>{color.name}</span><span className="inline-flex items-center gap-1 text-[10px] uppercase tracking-wide text-muted-foreground"><PlacementIcon role={color.role} /> {color.role}</span></div>

--- a/components/shell/AppShell.tsx
+++ b/components/shell/AppShell.tsx
@@ -45,12 +45,21 @@ export default function AppShell({ children }: { children:React.ReactNode }) {
           <nav className="hidden md:flex items-center gap-6 text-sm" aria-label="Primary">
             <Link href="/designers" className="hover:underline">Designers</Link>
             {!checking && !user && <Link href="/sign-in" className="hover:underline">Sign in / Sign up</Link>}
-            {user && <Link href="/account" aria-label="Account" className="rounded-full border border-white/15 bg-white/5 p-2 hover:bg-white/10 transition-colors"><User size={18} /><span className="sr-only">Account</span></Link>}
-            {user && <button onClick={signOut} className="text-sm hover:underline">Sign out</button>}
+            {user && (
+              <Link
+                href="/account"
+                aria-label="Account"
+                className="relative inline-flex rounded-full border border-white/15 bg-white/5 p-2 hover:bg-white/10 transition-colors"
+              >
+                <span className="absolute inset-[-6px]" aria-hidden />
+                <User size={18} />
+              </Link>
+            )}
+            {user && <button type="button" onClick={signOut} className="text-sm hover:underline">Sign out</button>}
           </nav>
           <div className="flex items-center gap-2">
             <ThemeToggle />
-            <button aria-label="Menu" className="md:hidden btn btn-secondary" onClick={()=>setMenuOpen(o=>!o)}><Menu size={18} /></button>
+            <button type="button" aria-label="Menu" className="md:hidden btn btn-secondary" onClick={()=>setMenuOpen(o=>!o)}><Menu size={18} /></button>
           </div>
         </div>
         {menuOpen && (
@@ -58,8 +67,17 @@ export default function AppShell({ children }: { children:React.ReactNode }) {
             <div className="flex flex-col gap-2 text-sm">
               <Link href="/designers" className="py-2">Designers</Link>
               {!user && <Link href="/sign-in" className="py-2">Sign in / Sign up</Link>}
-              {user && <Link href="/account" className="py-2 flex items-center gap-2"><User size={16} /><span className="sr-only">Account</span></Link>}
-              {user && <button onClick={signOut} className="py-2 text-left">Sign out</button>}
+              {user && (
+                <Link
+                  href="/account"
+                  aria-label="Account"
+                  className="relative inline-flex items-center py-2 gap-2"
+                >
+                  <span className="absolute inset-[-6px]" aria-hidden />
+                  <User size={16} />
+                </Link>
+              )}
+              {user && <button type="button" onClick={signOut} className="py-2 text-left">Sign out</button>}
             </div>
           </div>
         )}

--- a/components/subscribe-button.tsx
+++ b/components/subscribe-button.tsx
@@ -26,7 +26,7 @@ export function SubscribeButton({ priceId }: { priceId: string }) {
   }
 
   return (
-    <button
+    <button type="button"
       onClick={go}
       disabled={busy}
       className="rounded-2xl px-4 py-2 bg-black text-white"

--- a/components/ui/ThemeToggle.tsx
+++ b/components/ui/ThemeToggle.tsx
@@ -7,9 +7,9 @@ export default function ThemeToggle(){
   const [mounted,setMounted]=useState(false)
   useEffect(()=>{setMounted(true)},[])
   const current = resolvedTheme || theme
-  if(!mounted) return <button aria-label="Toggle theme" className="btn btn-secondary h-8 w-8 text-xs" title="Toggle theme">⋯</button>
+  if(!mounted) return <button type="button" aria-label="Toggle theme" className="btn btn-secondary h-8 w-8 text-xs" title="Toggle theme">⋯</button>
   return (
-    <button
+    <button type="button"
       aria-pressed={current==='dark'}
       onClick={()=> setTheme(current==='dark' ? 'light' : 'dark')}
       className="h-8 w-8 rounded-full flex items-center justify-center border bg-white text-neutral-700 hover:bg-neutral-100 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-emerald-500 transition-colors"

--- a/components/visual/HorizontalCarousel.tsx
+++ b/components/visual/HorizontalCarousel.tsx
@@ -48,10 +48,24 @@ export default function HorizontalCarousel({ children, className='', ariaLabel='
         {children}
       </div>
       <div className="hidden md:flex absolute inset-y-0 left-0 items-center">
-        <button aria-label="Scroll left" onClick={()=>scroll(-1)} className="h-9 w-9 rounded-full bg-white/80 backdrop-blur border border-[var(--border)] shadow-soft hover:bg-white transition" >‹</button>
+        <button
+          type="button"
+          aria-label="Scroll left"
+          onClick={() => scroll(-1)}
+          className="relative h-9 w-9 rounded-full bg-white/80 backdrop-blur border border-[var(--border)] shadow-soft hover:bg-white transition"
+        >
+          <span className="absolute inset-[-4px]" aria-hidden />‹
+        </button>
       </div>
       <div className="hidden md:flex absolute inset-y-0 right-0 items-center">
-        <button aria-label="Scroll right" onClick={()=>scroll(1)} className="h-9 w-9 rounded-full bg-white/80 backdrop-blur border border-[var(--border)] shadow-soft hover:bg-white transition" >›</button>
+        <button
+          type="button"
+          aria-label="Scroll right"
+          onClick={() => scroll(1)}
+          className="relative h-9 w-9 rounded-full bg-white/80 backdrop-blur border border-[var(--border)] shadow-soft hover:bg-white transition"
+        >
+          <span className="absolute inset-[-4px]" aria-hidden />›
+        </button>
       </div>
     </div>
   )

--- a/components/visual/SwatchRibbon.tsx
+++ b/components/visual/SwatchRibbon.tsx
@@ -17,7 +17,7 @@ export default function SwatchRibbon({ swatches }: SwatchRibbonProps){
       {swatches.slice(0,5).map((s,i)=> {
         const delay = reduced? 0 : i * 60
         return (
-        <button key={i} onClick={()=>copy(s.hex)} className={clsx('group relative h-14 w-14 rounded-xl border border-[var(--border)] shadow-soft focus:outline-none focus-visible:ring-2 focus-visible:ring-[var(--brand)] transition-all duration-[var(--dur-swatch)] ease-colrvia will-change-transform origin-bottom', copied===s.hex && 'ring-2 ring-[var(--brand)]')} style={{background:s.hex, animation: reduced? undefined : `swatchIn var(--dur-swatch) ${delay}ms both`}} aria-label={`Copy ${s.name||'swatch'} ${s.hex}`}>
+        <button type="button" key={i} onClick={()=>copy(s.hex)} className={clsx('group relative h-14 w-14 rounded-xl border border-[var(--border)] shadow-soft focus:outline-none focus-visible:ring-2 focus-visible:ring-[var(--brand)] transition-all duration-[var(--dur-swatch)] ease-colrvia will-change-transform origin-bottom', copied===s.hex && 'ring-2 ring-[var(--brand)]')} style={{background:s.hex, animation: reduced? undefined : `swatchIn var(--dur-swatch) ${delay}ms both`}} aria-label={`Copy ${s.name||'swatch'} ${s.hex}`}>
           <span className="sr-only">{copied===s.hex?'Copied ':''}{s.hex}</span>
           <span className="absolute -bottom-5 left-1/2 -translate-x-1/2 text-[10px] font-medium text-muted-foreground whitespace-nowrap">{s.name||s.hex}</span>
         </button>

--- a/styles/tokens.css
+++ b/styles/tokens.css
@@ -5,6 +5,8 @@
   --brand-saturation: 84%; /* saturation for primary brand color */
   --brand-light: 55%; /* lightness for primary brand color */
   --brand: hsl(var(--brand-hue) var(--brand-saturation) var(--brand-light)); /* primary brand color for interactive elements */
+  --brand-hover: oklch(0.58 0.17 264); /* slightly darker for contrast on hover */
+  --brand-contrast: oklch(0.98 0.01 95); /* near-white text for brand buttons */
   --brand-accent-hue: 20; /* hue for secondary accent color */
   --brand-accent: hsl(var(--brand-accent-hue) 90% 55%); /* warm accent used for highlights and warnings */
 

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -31,8 +31,8 @@ module.exports = {
       container: { center: true, padding: "16px" },
       maxWidth: { content: "72rem" }, // ~1152px
       fontFamily: {
-        sans: ["Inter", "ui-sans-serif", "system-ui", "sans-serif"],
-        display: ["Fraunces", "Inter", "ui-serif", "serif"],
+        sans: ["var(--font-inter)", "system-ui", "sans-serif"],
+        display: ["var(--font-fraunces)", "serif"],
       },
       boxShadow: {
         card: "0 6px 24px rgba(0,0,0,0.06)",


### PR DESCRIPTION
## Summary
- add accessible label and help text for new project name field
- enforce explicit button types and aria-current nav markers
- load fonts via `next/font`, add brand tokens, and enlarge icon tap targets

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689c1ebb534c832287ce5006ac5a4e50