### PR TITLE
feat: add mock render API and intake flow

### DIFF
--- a/app/(app)/intake/page.tsx
+++ b/app/(app)/intake/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { FormProvider, useForm } from "react-hook-form";
+import { useForm } from "react-hook-form";
 import { z } from "zod";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { useRouter } from "next/navigation";
@@ -8,150 +8,147 @@ import { TemplateChips } from "@/components/intake/TemplateChips";
 import { Progress } from "@/components/intake/Progress";
 import { LivePreview } from "@/components/intake/LivePreview";
 import { StickyCTA } from "@/components/intake/StickyCTA";
-import { FormField } from "@/components/form/FormField";
-// import { track } from "@/lib/analytics"; // if you added it
+import { uid } from "@/lib/uid";
 
 const IntakeSchema = z.object({
-  room: z.enum(["Living room","Bedroom","Kitchen","Bathroom","Workspace"], { required_error: "Pick a room" }),
-  style: z.enum(["Modern","Cozy","Minimalist","Mid-century","Scandinavian"], { required_error: "Pick a style" }),
-  budget: z.enum(["$","$$","$$$"]).optional(),
-  prompt: z.string().min(8, "Describe your space (8+ chars)")
+  room: z.enum(["Living room", "Bedroom", "Kitchen", "Bathroom", "Workspace"], { required_error: "Pick a room" }),
+  style: z.enum(["Modern", "Cozy", "Minimalist", "Mid-century", "Scandinavian"], { required_error: "Pick a style" }),
+  budget: z.enum(["$", "$$", "$$$"]).optional(),
+  prompt: z.string().min(8, "Describe your space (8+ chars)"),
 });
 
 type Intake = z.infer<typeof IntakeSchema>;
 
 const TEMPLATES = [
-  { label:"Modern living room", values:{ room:"Living room", style:"Modern", prompt:"Bright modern living room with natural light" } },
-  { label:"Cozy bedroom", values:{ room:"Bedroom", style:"Cozy", prompt:"Warm bedroom with layered textures" } },
-  { label:"Minimal workspace", values:{ room:"Workspace", style:"Minimalist", prompt:"Clutter-free workspace with clean lines" } },
+  { label: "Modern living room", values: { room: "Living room", style: "Modern", prompt: "Bright modern living room with natural light" } },
+  { label: "Cozy bedroom", values: { room: "Bedroom", style: "Cozy", prompt: "Warm bedroom with layered textures" } },
+  { label: "Minimal workspace", values: { room: "Workspace", style: "Minimalist", prompt: "Clutter-free workspace with clean lines" } },
 ];
 
 export default function IntakePage() {
   const router = useRouter();
-  const form = useForm<Intake>({
+  const {
+    register,
+    setValue,
+    handleSubmit,
+    formState: { errors, isSubmitting },
+    watch,
+    trigger,
+  } = useForm<Intake>({
     mode: "onBlur",
     resolver: zodResolver(IntakeSchema),
-    defaultValues: { room: undefined, style: undefined, budget: undefined, prompt: "" } as any,
+    defaultValues: { prompt: "" } as any,
   });
-  const { setValue, handleSubmit, formState: { isSubmitting }, watch } = form;
 
   const selection = { room: watch("room"), style: watch("style") };
 
   async function onSubmit(data: Intake) {
-    const t0 = performance.now();
-    // track({ name:"intake_submit", props:{ fields:Object.keys(data).length }});
-    // Optimistic frame: go to Reveal immediately with a temporary job id (client-side uid)
-    const tmpId = `tmp_${Math.random().toString(36).slice(2,9)}`;
-    router.push(`/reveal/${tmpId}?optimistic=1`);
+    const tempId = uid("tmp");
+    // Optimistic transition to Reveal
+    router.push(`/reveal/${tempId}?optimistic=1`);
 
-    // Kick off actual render job (replace with your action/api)
+    // Kick off the real job
     try {
-      // const job = await createRenderJob(data);
-      // track({ name:"render_started", props:{ job_id: job.id }});
-      // router.replace(`/reveal/${job.id}`);
-    } catch (e) {
-      // router.replace(`/reveal/error?reason=start-failed`);
-    } finally {
-      const ms = Math.round(performance.now() - t0);
-      // track({ name:"render_complete", props:{ job_id: tmpId, ms }});
+      const res = await fetch("/api/render", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify(data),
+      });
+      const { jobId } = (await res.json()) as { jobId: string };
+      if (jobId) router.replace(`/reveal/${jobId}`);
+      else router.replace(`/reveal/error?reason=no-job`);
+    } catch {
+      router.replace(`/reveal/error?reason=start-failed`);
     }
   }
 
   return (
     <div className="mx-auto max-w-6xl px-4 md:px-6 py-6 md:py-8 grid md:grid-cols-[1fr_340px] gap-6">
-      <FormProvider {...form}>
-        <form onSubmit={handleSubmit(onSubmit)} aria-describedby="intake-help">
-          <Progress step={1} total={2} />
-          <TemplateChips
-            templates={TEMPLATES}
-            onApply={(v) => {
-              Object.entries(v).forEach(([k, val]) =>
-                setValue(k as any, val, { shouldValidate: true })
-              );
-            }}
+      <form onSubmit={handleSubmit(onSubmit)} aria-describedby="intake-help">
+        <Progress step={1} total={2} />
+
+        <TemplateChips
+          templates={TEMPLATES}
+          onApply={(v) => {
+            Object.entries(v).forEach(([k, val]) => setValue(k as any, val, { shouldValidate: true }));
+          }}
+        />
+
+        {/* Room */}
+        <div className="mb-4">
+          <label htmlFor="room" className="text-sm font-medium">Room</label>
+          <select
+            id="room"
+            {...register("room")}
+            onBlur={() => trigger("room")}
+            className="mt-1 w-full rounded-xl border px-3 py-2"
+            aria-invalid={!!errors.room}
+            aria-describedby="room-help"
+          >
+            <option value="" hidden>Select a room</option>
+            {["Living room", "Bedroom", "Kitchen", "Bathroom", "Workspace"].map((r) => (
+              <option key={r} value={r}>{r}</option>
+            ))}
+          </select>
+          <p id="room-help" className="mt-1 text-xs text-neutral-500">
+            {errors.room?.message ?? "Pick the space you’re redesigning."}
+          </p>
+        </div>
+
+        {/* Style */}
+        <div className="mb-4">
+          <label htmlFor="style" className="text-sm font-medium">Style</label>
+          <select
+            id="style"
+            {...register("style")}
+            onBlur={() => trigger("style")}
+            className="mt-1 w-full rounded-xl border px-3 py-2"
+            aria-invalid={!!errors.style}
+            aria-describedby="style-help"
+          >
+            <option value="" hidden>Select a style</option>
+            {["Modern", "Cozy", "Minimalist", "Mid-century", "Scandinavian"].map((s) => (
+              <option key={s} value={s}>{s}</option>
+            ))}
+          </select>
+          <p id="style-help" className="mt-1 text-xs text-neutral-500">
+            {errors.style?.message ?? "We’ll tailor layouts, textures, and finishes."}
+          </p>
+        </div>
+
+        {/* Prompt */}
+        <div className="mb-6">
+          <label htmlFor="prompt" className="text-sm font-medium">Describe your space</label>
+          <textarea
+            id="prompt"
+            rows={4}
+            {...register("prompt")}
+            onBlur={() => trigger("prompt")}
+            placeholder="Natural light, wood accents, neutral palette…"
+            className="mt-1 w-full rounded-xl border px-3 py-2"
+            aria-invalid={!!errors.prompt}
+            aria-describedby="prompt-help"
           />
+          <p id="prompt-help" className="mt-1 text-xs text-neutral-500">
+            {errors.prompt?.message ?? "Add key constraints and preferences."}
+          </p>
+        </div>
 
-          {/* Room */}
-          <div className="mb-4">
-            <FormField name="room" label="Room" hint="Pick the space you’re redesigning.">
-              {({ id, error, field }) => (
-                <select
-                  id={id}
-                  {...field}
-                  className="w-full rounded-xl border px-3 py-2"
-                  aria-invalid={!!error}
-                  aria-describedby={`${id}-hint`}
-                >
-                  <option value="" hidden>
-                    Select a room
-                  </option>
-                  {["Living room", "Bedroom", "Kitchen", "Bathroom", "Workspace"].map((r) => (
-                    <option key={r} value={r}>
-                      {r}
-                    </option>
-                  ))}
-                </select>
-              )}
-            </FormField>
-          </div>
+        {/* Desktop CTA */}
+        <div className="hidden md:flex items-center gap-3">
+          <button
+            type="submit"
+            disabled={isSubmitting}
+            className="rounded-xl px-4 py-3 bg-brand text-brand-contrast hover:bg-brand-hover disabled:opacity-50"
+          >
+            Generate (≈12s)
+          </button>
+          <span className="text-xs text-neutral-500">Private to you · You can edit inputs later</span>
+        </div>
 
-          {/* Style */}
-          <div className="mb-4">
-            <FormField name="style" label="Style" hint="We’ll tailor layouts, textures, and finishes.">
-              {({ id, error, field }) => (
-                <select
-                  id={id}
-                  {...field}
-                  className="w-full rounded-xl border px-3 py-2"
-                  aria-invalid={!!error}
-                  aria-describedby={`${id}-hint`}
-                >
-                  <option value="" hidden>
-                    Select a style
-                  </option>
-                  {["Modern", "Cozy", "Minimalist", "Mid-century", "Scandinavian"].map((s) => (
-                    <option key={s} value={s}>
-                      {s}
-                    </option>
-                  ))}
-                </select>
-              )}
-            </FormField>
-          </div>
-
-          {/* Prompt */}
-          <div className="mb-6">
-            <FormField name="prompt" label="Describe your space" hint="Add key constraints and preferences.">
-              {({ id, error, field }) => (
-                <textarea
-                  id={id}
-                  rows={4}
-                  {...field}
-                  placeholder="Natural light, wood accents, neutral palette…"
-                  className="w-full rounded-xl border px-3 py-2"
-                  aria-invalid={!!error}
-                  aria-describedby={`${id}-hint`}
-                />
-              )}
-            </FormField>
-          </div>
-
-          {/* Desktop primary action */}
-          <div className="hidden md:flex items-center gap-3">
-            <button
-              type="submit"
-              disabled={isSubmitting}
-              className="rounded-xl px-4 py-3 bg-brand text-brand-contrast hover:bg-brand-hover disabled:opacity-50"
-            >
-              Generate (≈12s)
-            </button>
-            <span className="text-xs text-neutral-500">Private to you · You can edit inputs later</span>
-          </div>
-
-          {/* Mobile sticky CTA */}
-          <StickyCTA disabled={isSubmitting} />
-        </form>
-      </FormProvider>
+        {/* Mobile sticky CTA */}
+        <StickyCTA disabled={isSubmitting} />
+      </form>
 
       {/* Right rail preview (desktop) */}
       <div className="hidden md:block">

--- a/app/(app)/reveal/[id]/page.tsx
+++ b/app/(app)/reveal/[id]/page.tsx
@@ -1,24 +1,54 @@
-export default function RevealPage({ params, searchParams }:{ params:{ id:string }, searchParams:{ optimistic?:string } }) {
-  const optimistic = searchParams?.optimistic === "1";
+"use client";
+
+import { useEffect, useState } from "react";
+import { useRouter, useSearchParams } from "next/navigation";
+import { Skeleton } from "@/components/Skeleton";
+
+export default function RevealPage({ params }: { params: { id: string } }) {
+  const router = useRouter();
+  const searchParams = useSearchParams();
+  const optimistic = searchParams.get("optimistic") === "1";
+  const [ready, setReady] = useState(!optimistic && !params.id.startsWith("tmp_"));
+
+  useEffect(() => {
+    if (!optimistic && !params.id.startsWith("tmp_")) return;
+    let t = setInterval(async () => {
+      try {
+        const res = await fetch("/api/render", { method: "GET" });
+        const { status } = await res.json();
+        if (status === "ready") setReady(true);
+      } catch {}
+    }, 1000);
+    return () => clearInterval(t);
+  }, [optimistic, params.id]);
+
+  useEffect(() => {
+    // In a real app, when your backend returns the real jobId (via websocket/SSE/poll),
+    // call router.replace(`/reveal/${realId}`) then setReady(true).
+  }, []);
+
+  if (!ready) {
+    return (
+      <div className="mx-auto max-w-6xl px-4 md:px-6 py-6">
+        <h1 className="text-xl font-semibold mb-4">Generating your designs…</h1>
+        <div className="grid md:grid-cols-2 gap-4">
+          {Array.from({ length: 4 }).map((_, i) => (
+            <div key={i} className="rounded-xl border p-3">
+              <div className="aspect-video rounded-lg bg-neutral-200 animate-pulse mb-2" />
+              <Skeleton className="h-3 w-2/3" />
+            </div>
+          ))}
+        </div>
+        <p className="mt-3 text-xs text-neutral-500">This takes about 8–15 seconds. You can keep browsing.</p>
+      </div>
+    );
+  }
+
   return (
     <div className="mx-auto max-w-6xl px-4 md:px-6 py-6">
-      {optimistic ? (
-        <>
-          <h1 className="text-xl font-semibold mb-4">Generating your designs…</h1>
-          <div className="grid md:grid-cols-2 gap-4">
-            {Array.from({ length: 4 }).map((_,i) => (
-              <div key={i} className="rounded-xl border p-3">
-                <div className="aspect-video rounded-lg bg-neutral-200 animate-pulse mb-2" />
-                <div className="h-3 w-2/3 rounded bg-neutral-200 animate-pulse" />
-              </div>
-            ))}
-          </div>
-          <p className="mt-3 text-xs text-neutral-500">This takes about 8–15 seconds. You can keep browsing.</p>
-        </>
-      ) : (
-        /* …your real reveal UI… */
-        <div>/* render results */</div>
-      )}
+      {/* TODO: render real results here */}
+      <h1 className="text-xl font-semibold mb-4">Your designs</h1>
+      {/* … */}
     </div>
   );
 }

--- a/app/api/render/route.ts
+++ b/app/api/render/route.ts
@@ -1,0 +1,14 @@
+import { NextResponse } from "next/server";
+
+export async function POST(req: Request) {
+  const body = await req.json().catch(() => ({}));
+  // TODO: enqueue render job with your provider; return jobId from backend
+  const jobId = `job_${Math.random().toString(36).slice(2, 10)}`;
+  return NextResponse.json({ jobId, accepted: true });
+}
+
+// Optional GET to check status if you want to poll
+export async function GET() {
+  // This mock always claims "ready"
+  return NextResponse.json({ status: "ready" });
+}

--- a/components/Skeleton.tsx
+++ b/components/Skeleton.tsx
@@ -1,0 +1,5 @@
+export function Skeleton({ className = "h-40 w-full" }) {
+  return (
+    <div className={`animate-pulse rounded-lg bg-neutral-200/60 dark:bg-neutral-700/60 ${className}`} />
+  );
+}

--- a/lib/uid.ts
+++ b/lib/uid.ts
@@ -1,0 +1,3 @@
+export function uid(prefix = "tmp"): string {
+  return `${prefix}_${Math.random().toString(36).slice(2, 10)}`;
+}


### PR DESCRIPTION
## Summary
- add skeleton component and uid helper for temporary identifiers
- replace intake page to use template chips and optimistic job kick-off
- add reveal polling logic and mock /api/render endpoint

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689c23750bc88322b7f4c564ce6964a6