### PR TITLE
feat: add story creation pipeline

### DIFF
--- a/__tests__/layout/theme-moss-applied.test.tsx
+++ b/__tests__/layout/theme-moss-applied.test.tsx
@@ -2,6 +2,7 @@ import { describe, it, expect } from "vitest"
 import React from "react"
 import { renderToStaticMarkup } from "react-dom/server"
 import RootLayout from "@/app/layout"
+vi.mock("next/font/google", () => ({ Inter: () => ({ className: "" }), Fraunces: () => ({ className: "" }) }))
 vi.mock('@/components/auth-hash-listener', () => ({ default: () => null }))
 vi.mock('@/components/AppShell', () => ({ default: ({ children }: any) => <div>{children}</div> }))
 vi.mock('@/components/providers/AuthSyncBridge', () => ({ default: () => null }))

--- a/app/(app)/reveal/[id]/page.tsx
+++ b/app/(app)/reveal/[id]/page.tsx
@@ -1,48 +1,57 @@
-"use client"
-import { useEffect, useState } from 'react'
-import { supabaseBrowser } from '@/lib/supabase/browser'
-import { Skeleton } from '@/components/Skeleton'
-import { ActionsBar } from '@/components/reveal/ActionsBar'
-import { ResultCard } from '@/components/reveal/ResultCard'
+"use client";
+import { useEffect, useState } from "react";
+import { createBrowserClient } from "@supabase/ssr";
+import { Skeleton } from "@/components/Skeleton";
 
-type Job = { id:string; status:'queued'|'processing'|'ready'|'failed'; result: null | { images:{ url:string }[]; meta?:any }; error?: string | null }
+type Story = {
+  id: string;
+  status: "draft" | "queued" | "processing" | "ready" | "failed";
+  result: null | { images: { url: string }[]; meta?: any };
+  error?: string | null;
+};
 
-export default function RevealJobPage({ params }:{ params:{ id:string } }){
-  const supabase = supabaseBrowser()
-  const [job, setJob] = useState<Job | null>(null)
+export default function RevealPage({ params }: { params: { id: string } }) {
+  const supabase = createBrowserClient(
+    process.env.NEXT_PUBLIC_SUPABASE_URL!,
+    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!
+  );
+  const [story, setStory] = useState<Story | null>(null);
 
-  useEffect(()=> {
-    supabase.from('jobs').select('id,status,result,error').eq('id', params.id).single().then(({ data }) => {
-      if(data) setJob(data as Job)
-    })
-  },[params.id, supabase])
+  // Initial fetch
+  useEffect(() => {
+    supabase
+      .from("stories")
+      .select("id,status,result,error")
+      .eq("id", params.id)
+      .single()
+      .then(({ data }) => data && setStory(data as Story));
+  }, [params.id, supabase]);
 
-  useEffect(()=> {
-    const channel = supabase.channel(`job:${params.id}`)
-      .on('postgres_changes', { event:'*', schema:'public', table:'jobs', filter:`id=eq.${params.id}` }, (payload:any) => {
-        setJob(payload.new as Job)
-      })
-      .subscribe()
-    return () => { supabase.removeChannel(channel) }
-  },[params.id, supabase])
+  // Live updates
+  useEffect(() => {
+    const ch = supabase
+      .channel(`story:${params.id}`)
+      .on(
+        "postgres_changes",
+        { event: "*", schema: "public", table: "stories", filter: `id=eq.${params.id}` },
+        (p) => {
+          setStory(p.new as Story);
+        }
+      )
+      .subscribe();
+    return () => void supabase.removeChannel(ch);
+  }, [params.id, supabase]);
 
-  const ready = job?.status === 'ready'
-  const failed = job?.status === 'failed'
+  const ready = story?.status === "ready";
+  const failed = story?.status === "failed";
 
   return (
     <div className="mx-auto max-w-6xl px-4 md:px-6 py-6">
-      {failed && (
-        <div>
-          <h1 className="text-xl font-semibold mb-2">Something went wrong</h1>
-          <p className="text-sm text-neutral-600 mb-4">{job?.error || 'Please try again.'}</p>
-          <a href="/intake" className="inline-flex rounded-xl px-4 py-2 border">Try again</a>
-        </div>
-      )}
       {!ready && !failed && (
-        <div>
+        <>
           <h1 className="text-xl font-semibold mb-4">Generating your designs…</h1>
           <div className="grid md:grid-cols-2 gap-4">
-            {Array.from({ length:4 }).map((_,i)=>(
+            {Array.from({ length: 4 }).map((_, i) => (
               <div key={i} className="rounded-xl border p-3">
                 <div className="aspect-video rounded-lg bg-neutral-200 animate-pulse mb-2" />
                 <Skeleton className="h-3 w-2/3" />
@@ -50,19 +59,34 @@ export default function RevealJobPage({ params }:{ params:{ id:string } }){
             ))}
           </div>
           <p className="mt-3 text-xs text-neutral-500">This takes about 8–15 seconds. You can keep browsing.</p>
-        </div>
+        </>
+      )}
+      {failed && (
+        <>
+          <h1 className="text-xl font-semibold mb-2">Something went wrong</h1>
+          <p className="text-sm text-neutral-600 mb-4">{story?.error ?? "Please try again."}</p>
+          <a href="/intake" className="inline-flex rounded-xl px-4 py-2 border">Try again</a>
+        </>
       )}
       {ready && (
         <>
-          <ActionsBar jobId={job!.id} />
-          <h1 className="text-xl font-semibold mb-3">Your designs</h1>
+          <h1 className="text-xl font-semibold mb-4">Your designs</h1>
           <div className="grid md:grid-cols-2 gap-4">
-            {job?.result?.images?.map((img,i)=>(
-              <ResultCard key={i} url={img.url} index={i} jobId={job!.id} />
+            {story?.result?.images?.map((img, i) => (
+              <figure key={i} className="rounded-xl border overflow-hidden">
+                {/* eslint-disable-next-line @next/next/no-img-element */}
+                <img
+                  src={img.url}
+                  alt={`Variation ${i + 1}`}
+                  className="w-full h-auto"
+                  loading={i > 1 ? "lazy" : "eager"}
+                />
+                <figcaption className="p-2 text-sm text-neutral-600">Variation {i + 1}</figcaption>
+              </figure>
             ))}
           </div>
         </>
       )}
     </div>
-  )
+  );
 }

--- a/db/migrations/20251007_create_stories.sql
+++ b/db/migrations/20251007_create_stories.sql
@@ -1,0 +1,32 @@
+create table if not exists public.stories (
+  id uuid primary key default gen_random_uuid(),
+  user_id uuid not null references auth.users(id) on delete cascade,
+  title text,
+  status text not null default 'queued' check (status in ('draft','queued','processing','ready','failed')),
+  input jsonb not null,
+  result jsonb,
+  error text,
+  idempotency_key text,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now()
+);
+
+create index if not exists stories_user_id_idx on public.stories (user_id);
+create unique index if not exists stories_idem_uidx on public.stories (user_id, idempotency_key) where idempotency_key is not null;
+
+create or replace function public.touch_stories_updated_at()
+returns trigger language plpgsql as $$
+begin new.updated_at = now(); return new; end; $$;
+
+drop trigger if exists trg_touch_stories on public.stories;
+create trigger trg_touch_stories before update on public.stories
+for each row execute function public.touch_stories_updated_at();
+
+alter table public.stories enable row level security;
+
+create policy "read own stories" on public.stories
+  for select using (auth.uid() = user_id);
+create policy "insert own stories" on public.stories
+  for insert with check (auth.uid() = user_id);
+create policy "update own stories" on public.stories
+  for update using (auth.uid() = user_id);

--- a/lib/supabase/server.ts
+++ b/lib/supabase/server.ts
@@ -1,26 +1,12 @@
-import { cookies, headers } from "next/headers";
+import { cookies } from "next/headers";
 import { createServerClient } from "@supabase/ssr";
 
-export function supabaseServer() {
-  const cookieStore = cookies();
-  const headerList = headers();
-
+export function createSupabaseServer() {
   return createServerClient(
     process.env.NEXT_PUBLIC_SUPABASE_URL!,
     process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,
-    {
-      cookies: {
-        get(name: string) {
-          return cookieStore.get(name)?.value;
-        },
-        set(name: string, value: string, options: any) {
-          // Next 14 allows setting cookies in RSC/route handlers
-          cookieStore.set({ name, value, ...options });
-        },
-        remove(name: string, options: any) {
-          cookieStore.set({ name, value: "", ...options, maxAge: 0 });
-        },
-  }
-    }
+    { cookies }
   );
 }
+
+export const supabaseServer = createSupabaseServer;

--- a/supabase/functions/render-worker/index.ts
+++ b/supabase/functions/render-worker/index.ts
@@ -1,0 +1,45 @@
+import "jsr:@supabase/functions-js/edge-runtime.d.ts";
+import { createClient } from "https://esm.sh/@supabase/supabase-js@2";
+
+Deno.serve(async (req) => {
+  const { storyId, userId } = await req.json().catch(() => ({}));
+  const supabase = createClient(
+    Deno.env.get("SUPABASE_URL")!,
+    Deno.env.get("SUPABASE_SERVICE_ROLE_KEY")!
+  );
+
+  await supabase
+    .from("stories")
+    .update({ status: "processing" })
+    .eq("id", storyId)
+    .eq("user_id", userId);
+
+  try {
+    // TODO: call your renderer with input from DB
+    await new Promise((r) => setTimeout(r, 4000));
+    const result = {
+      images: [
+        { url: "https://picsum.photos/seed/a/1600/900" },
+        { url: "https://picsum.photos/seed/b/1600/900" },
+        { url: "https://picsum.photos/seed/c/1600/900" },
+        { url: "https://picsum.photos/seed/d/1600/900" },
+      ],
+      meta: { variations: 4, colorways: 2 },
+    };
+    await supabase
+      .from("stories")
+      .update({ status: "ready", result })
+      .eq("id", storyId)
+      .eq("user_id", userId);
+  } catch (e) {
+    await supabase
+      .from("stories")
+      .update({ status: "failed", error: String(e) })
+      .eq("id", storyId)
+      .eq("user_id", userId);
+  }
+
+  return new Response(JSON.stringify({ ok: true }), {
+    headers: { "content-type": "application/json" },
+  });
+});

--- a/tests/layout-skip-link.test.tsx
+++ b/tests/layout-skip-link.test.tsx
@@ -3,6 +3,7 @@ import { render, screen, waitFor } from "@testing-library/react"
 import RootLayout from "@/app/layout"
 
 // Provide minimal mocks for providers that instantiate Supabase or other side effects
+vi.mock("next/font/google", () => ({ Inter: () => ({ className: "" }), Fraunces: () => ({ className: "" }) }))
 vi.mock("next/script", () => ({ default: (props: any) => <>{props.children}</> }))
 vi.mock("@/components/providers/AuthSyncBridge", () => ({ default: () => null }))
 vi.mock("@/components/providers/SupabaseListener", () => ({ default: () => null }))


### PR DESCRIPTION
## Summary
- add stories table migration with idempotency and RLS
- implement Supabase helpers and idempotent `/api/story` route
- wire intake and reveal flows to new stories and add mock worker

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689c311ad4508322ad0feb3d2ad8bc27