### PR TITLE
Optimize reveal images with Next/Image and shimmer placeholders

### DIFF
--- a/app/(app)/reveal/[id]/page.tsx
+++ b/app/(app)/reveal/[id]/page.tsx
@@ -2,11 +2,13 @@
 import { useEffect, useState } from "react";
 import { createBrowserClient } from "@supabase/ssr";
 import { Skeleton } from "@/components/Skeleton";
+import { ActionsBar } from "@/components/reveal/ActionsBar";
+import { ResultCard } from "@/components/reveal/ResultCard";
 
 type Story = {
   id: string;
   status: "draft" | "queued" | "processing" | "ready" | "failed";
-  result: null | { images: { url: string }[]; meta?: any };
+  result: null | { images: { url: string; width?: number; height?: number }[]; meta?: any };
   error?: string | null;
 };
 
@@ -70,19 +72,18 @@ export default function RevealPage({ params }: { params: { id: string } }) {
       )}
       {ready && (
         <>
-          <h1 className="text-xl font-semibold mb-4">Your designs</h1>
+          <ActionsBar jobId={story!.id} />
+          <h1 className="text-xl font-semibold mb-3">Your designs</h1>
           <div className="grid md:grid-cols-2 gap-4">
             {story?.result?.images?.map((img, i) => (
-              <figure key={i} className="rounded-xl border overflow-hidden">
-                {/* eslint-disable-next-line @next/next/no-img-element */}
-                <img
-                  src={img.url}
-                  alt={`Variation ${i + 1}`}
-                  className="w-full h-auto"
-                  loading={i > 1 ? "lazy" : "eager"}
-                />
-                <figcaption className="p-2 text-sm text-neutral-600">Variation {i + 1}</figcaption>
-              </figure>
+              <ResultCard
+                key={i}
+                url={img.url}
+                index={i}
+                storyId={story!.id}
+                width={img.width ?? 1600}
+                height={img.height ?? 900}
+              />
             ))}
           </div>
         </>

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -67,6 +67,7 @@ export default async function RootLayout({
   const locale = getLocale()
   const messages = await getMessages(locale)
   const t = createTranslator({ locale, messages })
+  const imgHost = process.env.NEXT_PUBLIC_SUPABASE_URL
 
   return (
     <html lang={locale} className={cn('theme-moss', inter.variable, fraunces.variable)}>
@@ -74,6 +75,7 @@ export default async function RootLayout({
         <meta name="theme-color" content="#F7F5EF" />
         <meta name="theme-color" media="(prefers-color-scheme: dark)" content="#121212" />
         <meta name="color-scheme" content="light dark" />
+        {imgHost && <link rel="preconnect" href={imgHost} crossOrigin="" />}
       </head>
       <body
         className={cn(

--- a/components/reveal/ResultCard.tsx
+++ b/components/reveal/ResultCard.tsx
@@ -1,49 +1,44 @@
-"use client"
+"use client";
 
-import { downloadFile, copyToClipboard } from '@/lib/client/download'
-import { useToast } from '@/components/ui/Toast'
+import Image from "next/image";
+import { shimmer, toBase64 } from "@/lib/image-placeholder";
+import { downloadFile, copyToClipboard } from "@/lib/client/download";
+import { useToast } from "@/components/ui/Toast";
 
-export function ResultCard({ url, index, jobId }: { url: string; index: number; jobId: string }) {
-  const { show, ToastEl } = useToast()
-  const filename = `colrvia-${jobId}-${String(index + 1).padStart(2, '0')}.${(url.split('?')[0].split('.').pop() || 'jpg')}`
+type Props = { url: string; index: number; storyId: string; width?: number; height?: number };
+export function ResultCard({ url, index, storyId, width = 1600, height = 900 }: Props) {
+  const { show, ToastEl } = useToast();
+  const ext = (url.split("?")[0].split(".").pop() || "jpg").toLowerCase();
+  const filename = `colrvia-${storyId}-${String(index + 1).padStart(2, "0")}.${ext}`;
 
-  async function onDownload() {
-    await downloadFile(url, filename)
-    show('Downloading…')
-  }
-  async function onCopyLink() {
-    const ok = await copyToClipboard(url)
-    show(ok ? 'Image link copied!' : 'Couldn’t copy link')
-  }
+  async function onDownload() { await downloadFile(url, filename); show("Downloading…"); }
+  async function onCopyLink() { show((await copyToClipboard(url)) ? "Image link copied!" : "Couldn’t copy"); }
 
   return (
     <figure className="group relative rounded-xl border overflow-hidden">
-      {/* eslint-disable-next-line @next/next/no-img-element */}
-      <img src={url} alt={`Variation ${index + 1}`} className="w-full h-auto block" loading={index > 1 ? 'lazy' : 'eager'} />
-      <figcaption id={`cap-${index}`} className="p-2 text-sm text-neutral-600">Variation {index + 1}</figcaption>
+      <Image
+        src={url}
+        alt={`Variation ${index + 1}`}
+        width={width}
+        height={height}
+        sizes="(max-width: 768px) 100vw, 50vw"
+        placeholder="blur"
+        blurDataURL={`data:image/svg+xml;base64,${toBase64(shimmer(width, height))}`}
+        priority={index < 2}
+        decoding="async"
+        className="block w-full h-auto"
+      />
 
-      {/* Overlay actions */}
+      <figcaption className="p-2 text-sm text-neutral-600">Variation {index + 1}</figcaption>
+
+      {/* Overlay actions (unchanged) */}
       <div className="absolute top-2 right-2 opacity-0 group-hover:opacity-100 transition-opacity">
         <div role="group" aria-label={`Actions for variation ${index + 1}`} className="flex gap-1">
-          <button
-            type="button"
-            onClick={onDownload}
-            aria-label="Download image"
-            className="rounded-md bg-white/90 dark:bg-neutral-900/90 backdrop-blur border px-2 py-1 text-xs hover:bg-white"
-          >
-            ⬇️
-          </button>
-          <button
-            type="button"
-            onClick={onCopyLink}
-            aria-label="Copy image link"
-            className="rounded-md bg-white/90 dark:bg-neutral-900/90 backdrop-blur border px-2 py-1 text-xs hover:bg-white"
-          >
-            🔗
-          </button>
+          <button type="button" onClick={onDownload} aria-label="Download image" className="rounded-md bg-white/90 dark:bg-neutral-900/90 backdrop-blur border px-2 py-1 text-xs">⬇️</button>
+          <button type="button" onClick={onCopyLink} aria-label="Copy image link" className="rounded-md bg-white/90 dark:bg-neutral-900/90 backdrop-blur border px-2 py-1 text-xs">🔗</button>
         </div>
       </div>
       {ToastEl}
     </figure>
-  )
+  );
 }

--- a/lib/image-placeholder.ts
+++ b/lib/image-placeholder.ts
@@ -1,0 +1,10 @@
+export function shimmer(w = 1600, h = 900) {
+  return `
+  <svg width="${w}" height="${h}" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 ${w} ${h}" preserveAspectRatio="none">
+    <defs><linearGradient id="g"><stop stop-color="#eee" offset="20%" /><stop stop-color="#ddd" offset="50%" /><stop stop-color="#eee" offset="70%" /></linearGradient></defs>
+    <rect width="${w}" height="${h}" fill="#eee"/><rect id="r" width="${w}" height="${h}" fill="url(#g)"/>
+    <animate xlink:href="#r" attributeName="x" from="-${w}" to="${w}" dur="1s" repeatCount="indefinite"  />
+  </svg>`;
+}
+export const toBase64 = (s: string) =>
+  typeof window === "undefined" ? Buffer.from(s).toString("base64") : window.btoa(s);

--- a/next.config.js
+++ b/next.config.js
@@ -7,6 +7,12 @@ if (process.env.VITEST_WORKER_ID == null) {
 /** @type {import('next').NextConfig} */
 const nextConfig = {
   reactStrictMode: true,
+  images: {
+    remotePatterns: [
+      { protocol: 'https', hostname: '**.supabase.co' },
+      { protocol: 'https', hostname: 'picsum.photos' }
+    ]
+  },
   async redirects() {
     return [
       { source: '/projects', destination: '/dashboard', permanent: true },


### PR DESCRIPTION
## Summary
- configure Next.js image domains for Supabase and picsum
- add SVG shimmer placeholder utility
- switch Reveal result cards to `next/image` with blur and sizing
- thread image dimensions and add actions bar in reveal page
- preconnect to Supabase image host for faster loads

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689c3334beac8322b4f7769a3a31c2f0