### PR TITLE
feat: auto finish reveal with polling

### DIFF
--- a/app/(app)/intake/page.tsx
+++ b/app/(app)/intake/page.tsx
@@ -62,7 +62,7 @@ export default function IntakePage() {
       const json = (await res.json()) as { storyId?: string };
       if (json.storyId) {
         track("render_started", { story_id: json.storyId });
-        router.replace(`/reveal/${json.storyId}`);
+        router.replace(`/reveal/${json.storyId}?optimistic=1`); // keep skeleton until ready
         return;
       }
     } catch (e) {

--- a/app/(shell)/reveal/[id]/page.tsx
+++ b/app/(shell)/reveal/[id]/page.tsx
@@ -10,6 +10,7 @@ import CopyToast from '@/components/reveal/CopyToast'
 import StoryHeroCard from '@/components/visual/StoryHeroCard'
 import SwatchRibbon from '@/components/visual/SwatchRibbon'
 import PdfButton from './pdf-button'
+import RevealPoller from '@/components/reveal/RevealPoller'
 import { normalizePalette } from '@/lib/palette'
 import { repairStoryPalette } from '@/lib/palette/repair'
 import RevealPaletteClient from './RevealPaletteClient'
@@ -49,6 +50,8 @@ export default async function RevealStoryPage({ params, searchParams }:{ params:
   if (optimistic) {
     return (
       <div className="mx-auto max-w-6xl px-4 md:px-6 py-6">
+        {/* ensure we auto-finish when it's a real id */}
+        {!id.startsWith("tmp_") && <RevealPoller id={id} />}
         <h1 className="text-xl font-semibold mb-4">Generating your designs…</h1>
         <div className="grid md:grid-cols-2 gap-4">
           {Array.from({ length: 4 }).map((_,i) => (

--- a/app/api/stories/[id]/status/route.ts
+++ b/app/api/stories/[id]/status/route.ts
@@ -1,0 +1,17 @@
+import { NextResponse } from "next/server";
+import { createSupabaseServer } from "@/lib/supabase/server";
+
+export async function GET(_: Request, { params }: { params: { id: string } }) {
+  const supabase = createSupabaseServer();
+  const { data: { user } } = await supabase.auth.getUser();
+  if (!user) return NextResponse.json({ error: "unauthorized" }, { status: 401 });
+
+  const { data, error } = await supabase
+    .from("stories")
+    .select("status")
+    .eq("id", params.id)
+    .single();
+
+  if (error || !data) return NextResponse.json({ error: "not_found" }, { status: 404 });
+  return NextResponse.json({ status: data.status });
+}

--- a/components/reveal/RevealPoller.tsx
+++ b/components/reveal/RevealPoller.tsx
@@ -1,0 +1,39 @@
+"use client";
+import { useEffect, useRef } from "react";
+import { useRouter, useSearchParams } from "next/navigation";
+import { track } from "@/lib/analytics/client";
+
+export default function RevealPoller({ id }: { id: string }) {
+  const router = useRouter();
+  const params = useSearchParams();
+  const once = useRef(false);
+  const optimistic = params.get("optimistic") === "1";
+
+  useEffect(() => {
+    if (!optimistic) return;
+    if (id.startsWith("tmp_")) return; // tmp IDs just show skeleton
+
+    let alive = true;
+    const tick = async () => {
+      try {
+        const res = await fetch(`/api/stories/${id}/status`, { cache: "no-store" });
+        if (!res.ok) return;
+        const { status } = (await res.json()) as { status: string };
+        if (alive && status === "ready" && !once.current) {
+          once.current = true;
+          track("render_complete", { story_id: id });
+          // remove ?optimistic=1 and render final page
+          const url = new URL(location.href);
+          url.searchParams.delete("optimistic");
+          router.replace(url.toString());
+          return;
+        }
+      } catch {}
+      if (alive) setTimeout(tick, 900);
+    };
+    tick();
+    return () => { alive = false; };
+  }, [id, optimistic, router]);
+
+  return null;
+}

--- a/supabase/functions/render-worker/index.ts
+++ b/supabase/functions/render-worker/index.ts
@@ -20,10 +20,10 @@ Deno.serve(async (req) => {
     await new Promise((r) => setTimeout(r, 4000));
     const result = {
       images: [
-        { url: "https://picsum.photos/seed/a/1600/900" },
-        { url: "https://picsum.photos/seed/b/1600/900" },
-        { url: "https://picsum.photos/seed/c/1600/900" },
-        { url: "https://picsum.photos/seed/d/1600/900" },
+        { url: "https://picsum.photos/seed/a/1600/900", width: 1600, height: 900 },
+        { url: "https://picsum.photos/seed/b/1600/900", width: 1600, height: 900 },
+        { url: "https://picsum.photos/seed/c/1600/900", width: 1600, height: 900 },
+        { url: "https://picsum.photos/seed/d/1600/900", width: 1600, height: 900 },
       ],
       meta: { variations: 4, colorways: 2 },
     };


### PR DESCRIPTION
## Summary
- add status API for story rendering
- poll story status on reveal to auto-finish and track render_complete
- keep optimistic skeleton until final results and include image dimensions in worker

## Testing
- `npm test`
- `npm run lint`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_689c3d62cab4832299e0e74387f87982