### PR TITLE
Update therapist designer links to new preferences route

### DIFF
--- a/app/(app)/reveal/[id]/page.tsx
+++ b/app/(app)/reveal/[id]/page.tsx
@@ -44,7 +44,7 @@ export default function RevealPage({ params }: { params: { id: string } }) {
       <div className="mx-auto max-w-6xl px-4 md:px-6 py-6">
         <h1 className="text-xl font-semibold mb-2">{copy.reveal.errorTitle}</h1>
         <p className="text-sm text-neutral-600 mb-4">{story?.error ?? copy.reveal.errorSub}</p>
-        <a href="/intake" className="inline-flex rounded-xl px-4 py-2 border">Try again</a>
+        <a href="/preferences/therapist" className="inline-flex rounded-xl px-4 py-2 border">Try again</a>
       </div>
     );
   }

--- a/app/sitemap.ts
+++ b/app/sitemap.ts
@@ -3,6 +3,6 @@ export default function sitemap(): MetadataRoute.Sitemap {
   const base = process.env.NEXT_PUBLIC_SITE_URL ?? "https://example.com";
   return [
     { url: `${base}/`, changeFrequency: "weekly", priority: 1 },
-    { url: `${base}/intake`, changeFrequency: "monthly", priority: 0.8 },
+    { url: `${base}/preferences/therapist`, changeFrequency: "monthly", priority: 0.8 },
   ];
 }

--- a/components/DesignerCard.tsx
+++ b/components/DesignerCard.tsx
@@ -10,7 +10,7 @@ export default function DesignerCard({ d }: { d: DesignerProfile }) {
       <div className="text-neutral-600">{d.tagline}</div>
       <div className="text-neutral-500 text-sm mt-2">{d.style}</div>
       <Link
-        href={d.id === 'therapist' ? '/intake' : `/preferences/${d.id}`}
+        href={d.id === 'therapist' ? '/preferences/therapist' : `/preferences/${d.id}`}
         className="inline-block mt-4 rounded-xl px-4 py-2 bg-black text-white"
       >
         Choose {d.name.split(' ')[0]}

--- a/components/ai/DesignersGrid.tsx
+++ b/components/ai/DesignersGrid.tsx
@@ -16,9 +16,9 @@ export default function DesignersGrid(){
           <p className="text-sm text-muted-foreground mb-4">{d.tagline}</p>
           {d.pro && <span className="inline-flex items-center gap-1 text-[10px] uppercase tracking-wide bg-black text-white px-2 py-1 rounded-full w-fit mb-3">Pro</span>}
           <div className="mt-auto">
-            <Button
+          <Button
               as={Link}
-              href={d.id === 'therapist' ? '/intake' : `/preferences/${d.id}`}
+              href={d.id === 'therapist' ? '/preferences/therapist' : `/preferences/${d.id}`}
               className="w-full"
               onClick={() => track('designer_select', { designerId: d.id })}
               aria-label={`Start with ${d.name}`}


### PR DESCRIPTION
## Summary
- Route therapist designer selections through `/preferences/therapist`
- Update "Try again" navigation and sitemap entry

## Testing
- `npm test` *(fails: browserType.launch: Executable doesn't exist at /root/.cache/ms-playwright/chromium_headless_shell-1181/chrome-linux/headless_shell)*
- `npm run lint`
- `npm run typecheck` *(fails: TS2769: No overload matches this call)*

------
https://chatgpt.com/codex/tasks/task_e_689c441393508322b5e76e6509d8ea71