### PR TITLE
test: update intake route to preferences

### DIFF
--- a/tests/a11y.smoke.spec.ts
+++ b/tests/a11y.smoke.spec.ts
@@ -1,7 +1,7 @@
 import { test, expect } from "@playwright/test";
 import AxeBuilder from "@axe-core/playwright";
 test("intake page a11y smoke", async ({ page }) => {
-  await page.goto("/intake");
+  await page.goto("/preferences/therapist");
   const { violations } = await new AxeBuilder({ page }).analyze();
   expect(violations.filter(v => v.impact === "critical")).toEqual([]);
 });


### PR DESCRIPTION
## Summary
- update intake e2e tests to hit new /preferences/therapist onboarding route
- mock new intake chat API endpoints and expectations
- adjust a11y smoke test for new intake path

## Testing
- `npm test` *(fails: net::ERR_ABORTED, missing server for reveal tmp_test)*

------
https://chatgpt.com/codex/tasks/task_e_689c441a5b048322ad38214e041a1ff5