### PR TITLE
fix zip download route types

### DIFF
--- a/app/api/jobs/[id]/download-zip/route.ts
+++ b/app/api/jobs/[id]/download-zip/route.ts
@@ -23,12 +23,12 @@ export async function GET(_: Request, { params }: { params: { id: string } }) {
   for (const url of images) {
     const res = await fetch(url)
     if (!res.ok) continue
-    const buf = Buffer.from(await res.arrayBuffer())
+    const buf = new Uint8Array(await res.arrayBuffer())
     const ext = url.split('?')[0].split('.').pop() || 'jpg'
     zip.file(`colrvia-${params.id}-${String(idx).padStart(2, '0')}.${ext}`, buf)
     idx++
   }
-  const out = await zip.generateAsync({ type: 'nodebuffer' })
+  const out = await zip.generateAsync({ type: 'arraybuffer' })
   return new NextResponse(out, {
     headers: {
       'content-type': 'application/zip',

--- a/app/api/stories/[id]/download-zip/route.ts
+++ b/app/api/stories/[id]/download-zip/route.ts
@@ -23,12 +23,12 @@ export async function GET(_: Request, { params }: { params: { id: string } }) {
   for (const url of images) {
     const res = await fetch(url);
     if (!res.ok) continue;
-    const buf = Buffer.from(await res.arrayBuffer());
+    const buf = new Uint8Array(await res.arrayBuffer());
     const ext = url.split("?")[0].split(".").pop() || "jpg";
     zip.file(`colrvia-${params.id}-${String(idx).padStart(2, "0")}.${ext}`, buf);
     idx++;
   }
-  const out = await zip.generateAsync({ type: "nodebuffer" });
+  const out = await zip.generateAsync({ type: "arraybuffer" });
   return new NextResponse(out, {
     headers: {
       "content-type": "application/zip",

--- a/next-intl.config.ts
+++ b/next-intl.config.ts
@@ -1,0 +1,6 @@
+import {locales, defaultLocale} from './lib/i18n'
+
+export default {
+  locales,
+  defaultLocale
+}


### PR DESCRIPTION
## Summary
- fix zip archive routes to use Uint8Array inputs and ArrayBuffer output
- add next-intl config to satisfy build

## Testing
- `npm run build`
- `npm test` *(fails: net::ERR_CONNECTION_REFUSED at http://localhost:3000/preferences/therapist)*

------
https://chatgpt.com/codex/tasks/task_e_689c4e74b4788322b72a5a2e4afddae0