### PR TITLE
feat: wrap Next.js config with Next-Intl plugin

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -1,4 +1,6 @@
-/** @type {import('next').NextConfig} */
+const createNextIntlPlugin = require('next-intl/plugin');
+const withNextIntl = createNextIntlPlugin();
+
 const csp = `
 default-src 'self';
 script-src 'self' 'unsafe-inline' https://app.posthog.com https://*.supabase.co;
@@ -10,7 +12,8 @@ frame-ancestors 'self';
 base-uri 'self';
 form-action 'self';`.replace(/\n/g, " ");
 
-module.exports = {
+/** @type {import('next').NextConfig} */
+const nextConfig = {
   images: {
     remotePatterns: [
       { protocol: "https", hostname: "picsum.photos" },
@@ -33,3 +36,5 @@ module.exports = {
     ];
   }
 };
+
+module.exports = withNextIntl(nextConfig);


### PR DESCRIPTION
## Summary
- integrate `next-intl` plugin into `next.config.js`
- wrap existing Next.js configuration with the intl plugin

## Testing
- `npm run lint`
- `npm run typecheck`
- `npm test` *(fails: browserType.launch: Executable doesn't exist at /root/.cache/ms-playwright/...)*

------
https://chatgpt.com/codex/tasks/task_e_689c56824f488322be3c204498d90dcb