### PR TITLE
Replace therapist preferences with intake landing

### DIFF
--- a/app/(app)/intake/chat/page.tsx
+++ b/app/(app)/intake/chat/page.tsx
@@ -1,0 +1,10 @@
+'use client';
+import VoiceMic from '@/components/assistant/VoiceMic';
+
+export default function IntakeVoicePage() {
+  return (
+    <main className="min-h-[100dvh] flex items-center justify-center p-6">
+      <VoiceMic autoStart />
+    </main>
+  );
+}

--- a/app/(app)/intake/form/page.tsx
+++ b/app/(app)/intake/form/page.tsx
@@ -1,0 +1,12 @@
+import PreferencesChat from '@/components/ai/OnboardingChat';
+import { DEFAULT_DESIGNER_ID } from '@/lib/ai/designers';
+
+export const dynamic = 'force-dynamic';
+
+export default function IntakeFormPage() {
+  return (
+    <main className="max-w-3xl mx-auto px-4 py-10 space-y-6">
+      <PreferencesChat designerId={DEFAULT_DESIGNER_ID} />
+    </main>
+  );
+}

--- a/app/(app)/intake/page.tsx
+++ b/app/(app)/intake/page.tsx
@@ -79,7 +79,6 @@ export default function IntakeLanding() {
           title="Start voice chat"
           badge="Recommended"
           bullets={["Speak or type", "Upload photos", "Done in ~3–5 min"]}
-          icon="🎤"
         />
         <ModeCard
           role="radio"
@@ -89,7 +88,6 @@ export default function IntakeLanding() {
           onClick={() => setMode("form")}
           title="Fill out a form instead"
           bullets={["No mic needed", "Finish in ~4–6 min"]}
-          icon="📝"
           subtle
         />
 
@@ -195,7 +193,7 @@ function ModeCard({
   onClick: () => void;
   title: string;
   bullets: string[];
-  icon: string;
+  icon?: string;
   badge?: string;
   subtle?: boolean;
 } & React.ButtonHTMLAttributes<HTMLButtonElement>) {
@@ -216,9 +214,11 @@ function ModeCard({
       ].join(" ")}
     >
       <div className="flex items-start gap-3">
-        <span className="text-xl leading-none pt-0.5" aria-hidden>
-          {icon}
-        </span>
+        {icon && (
+          <span className="text-xl leading-none pt-0.5" aria-hidden>
+            {icon}
+          </span>
+        )}
 
         <div className="flex-1">
           <div className="flex items-center gap-2">

--- a/app/(shell)/start/page.tsx
+++ b/app/(shell)/start/page.tsx
@@ -10,7 +10,7 @@ export default function StartPage(){
         <h1 className="font-display text-4xl leading-[1.05] mb-4">Start</h1>
         <p className="text-sm text-[var(--color-fg-muted)] max-w-md">We’ll guide you with our default designer. You can explore other voices later.</p>
       </header>
-      <Link href={`/preferences/${DEFAULT_DESIGNER_ID}`} className="btn btn-primary w-full sm:w-auto">Get my palette</Link>
+      <Link href="/intake" className="btn btn-primary w-full sm:w-auto">Get my palette</Link>
   <p className="text-xs text-muted-foreground">Want to meet all designers? <Link href="/designers" className="underline">See them here</Link>.</p>
     </main>
   )

--- a/app/preferences/[designerId]/page.tsx
+++ b/app/preferences/[designerId]/page.tsx
@@ -22,7 +22,7 @@ export default async function PreferencesPage({ params }: { params:{ designerId:
         <div className="rounded-2xl border bg-[var(--bg-surface)] p-6 space-y-4">
           <p className="text-sm">This designer is a <strong>Pro</strong> feature.</p>
           <div className="flex flex-col sm:flex-row gap-3">
-            <Link href={`/preferences/${DEFAULT_DESIGNER_ID}`} className="btn btn-secondary flex-1">Continue with default</Link>
+            <Link href="/intake" className="btn btn-secondary flex-1">Continue with default</Link>
             <UpgradeButton className="btn btn-primary flex-1" />
           </div>
           {!user && <p className="text-[11px] text-muted-foreground">You’ll need to sign in during checkout.</p>}

--- a/app/preferences/therapist/page.tsx
+++ b/app/preferences/therapist/page.tsx
@@ -1,0 +1,5 @@
+import { redirect } from 'next/navigation';
+
+export default function TherapistPreferencesRedirect() {
+  redirect('/intake');
+}

--- a/app/sitemap.ts
+++ b/app/sitemap.ts
@@ -3,6 +3,6 @@ export default function sitemap(): MetadataRoute.Sitemap {
   const base = process.env.NEXT_PUBLIC_SITE_URL ?? "https://example.com";
   return [
     { url: `${base}/`, changeFrequency: "weekly", priority: 1 },
-    { url: `${base}/preferences/therapist`, changeFrequency: "monthly", priority: 0.8 },
+    { url: `${base}/intake`, changeFrequency: "monthly", priority: 0.8 },
   ];
 }

--- a/components/DesignerCard.tsx
+++ b/components/DesignerCard.tsx
@@ -10,7 +10,7 @@ export default function DesignerCard({ d }: { d: DesignerProfile }) {
       <div className="text-neutral-600">{d.tagline}</div>
       <div className="text-neutral-500 text-sm mt-2">{d.style}</div>
       <Link
-        href={d.id === 'therapist' ? '/preferences/therapist' : `/preferences/${d.id}`}
+        href={d.id === 'therapist' ? '/intake' : `/preferences/${d.id}`}
         className="inline-block mt-4 rounded-xl px-4 py-2 bg-black text-white"
       >
         Choose {d.name.split(' ')[0]}

--- a/components/ai/DesignersGrid.tsx
+++ b/components/ai/DesignersGrid.tsx
@@ -18,7 +18,7 @@ export default function DesignersGrid(){
           <div className="mt-auto">
           <Button
               as={Link}
-              href={d.id === 'therapist' ? '/preferences/therapist' : `/preferences/${d.id}`}
+              href={d.id === 'therapist' ? '/intake' : `/preferences/${d.id}`}
               className="w-full"
               onClick={() => track('designer_select', { designerId: d.id })}
               aria-label={`Start with ${d.name}`}

--- a/components/assistant/VoiceMic.tsx
+++ b/components/assistant/VoiceMic.tsx
@@ -1,7 +1,7 @@
 "use client";
 import React from "react";
 
-type Props = { onActiveChange?: (active: boolean) => void; greet?: string | null };
+type Props = { onActiveChange?: (active: boolean) => void; greet?: string | null; autoStart?: boolean };
 
 declare global {
   interface Window {
@@ -13,7 +13,7 @@ declare global {
   }
 }
 
-export default function VoiceMic({ onActiveChange, greet }: Props) {
+export default function VoiceMic({ onActiveChange, greet, autoStart }: Props) {
   const [active, setActive] = React.useState(false);
   const [error, setError] = React.useState<string | null>(null);
   const pcRef = React.useRef<RTCPeerConnection | null>(null);
@@ -122,6 +122,12 @@ export default function VoiceMic({ onActiveChange, greet }: Props) {
   function stop() {
     window.colrviaVoice?.stop();
   }
+
+  React.useEffect(() => {
+    if (autoStart) {
+      start();
+    }
+  }, [autoStart]);
 
   return (
     <div className="flex items-center gap-3" aria-busy={active || undefined}>

--- a/e2e/intake-flow.pw.ts
+++ b/e2e/intake-flow.pw.ts
@@ -22,7 +22,10 @@ test.describe("Intake flow", () => {
     await page.goto("/designers")
     await page.getByRole("link", { name: /start with color therapist/i }).click()
 
-    await expect(page).toHaveURL(/\/preferences\/therapist$/)
+    await expect(page).toHaveURL(/\/intake$/)
+    await page.getByRole("radio", { name: /fill out a form/i }).click()
+    await page.getByRole("button", { name: /start form/i }).click()
+    await expect(page).toHaveURL(/\/intake\/form$/)
     await expect(page.getByText("Which room?")).toBeVisible()
   })
 
@@ -70,12 +73,12 @@ test.describe("Intake flow", () => {
       }
     })
 
-    await page.goto("/preferences/therapist")
+    await page.goto("/intake/form")
     await page.getByRole("button", { name: /sherwin/i }).click()
 
     await expect(page).toHaveURL(/\/sign-in$/)
 
-    await page.goto("/preferences/therapist")
+    await page.goto("/intake/form")
     await page.getByRole("button", { name: /sherwin/i }).click()
 
     await expect(page).toHaveURL(/\/reveal\/story-123/)

--- a/tests/a11y.smoke.spec.ts
+++ b/tests/a11y.smoke.spec.ts
@@ -1,7 +1,7 @@
 import { test, expect } from "@playwright/test";
 import AxeBuilder from "@axe-core/playwright";
 test("intake page a11y smoke", async ({ page }) => {
-  await page.goto("/preferences/therapist");
+  await page.goto("/intake/form");
   const { violations } = await new AxeBuilder({ page }).analyze();
   expect(violations.filter(v => v.impact === "critical")).toEqual([]);
 });


### PR DESCRIPTION
## Summary
- remove `/preferences/therapist` in favour of `/intake`
- add voice chat and form intake pages with auto-starting voice mic
- drop microphone and pencil emojis from intake chooser

## Testing
- `npm test` *(fails: net::ERR_CONNECTION_REFUSED to http://localhost:3000)*

------
https://chatgpt.com/codex/tasks/task_e_689c5a95f2788322b8f69bccde335a79