### PR TITLE
feat: add type reveal hero for intake

### DIFF
--- a/app/(app)/intake/page.tsx
+++ b/app/(app)/intake/page.tsx
@@ -2,6 +2,8 @@
 
 import { useRouter } from "next/navigation";
 import { useEffect, useId, useState } from "react";
+import TypeReveal from "@/components/motion/TypeReveal";
+import "@/styles/brand-surface.css";
 
 /**
  * DESIGN-ONLY INTAKE LANDING
@@ -31,21 +33,28 @@ export default function IntakeLanding() {
   }
 
   return (
-    <div className="min-h-[100dvh] bg-gradient-to-b from-[#0D2C22] to-[#143629] text-[#F7F6F3]">
+    <div className="min-h-[100dvh] bg-colrvia-surface text-[#F7F6F3]">
       {/* Header */}
-      <header className="mx-auto max-w-md px-5 pt-6 pb-2 flex items-center gap-3">
+      <header className="mx-auto max-w-3xl px-6 pt-8 pb-2 flex items-center gap-3">
         <BackButton onClick={() => router.back()} />
         <DesignerChip name="Moss AI" avatarAlt="Moss AI avatar" />
       </header>
 
       {/* Hero */}
-      <section className="mx-auto max-w-md px-5">
-        {/* H1 visible for brand feel; keep it short */}
-        <h1 className="font-serif text-[56px] leading-[0.95] tracking-tight mb-2">hi.</h1>
-        {/* Visually secondary intro */}
-        <p className="text-sm opacity-90">
-          I’ll ask a few questions and create options for your space.
-        </p>
+      <section className="mx-auto max-w-3xl px-6">
+        <TypeReveal
+          as="h1"
+          text="hi."
+          speed={90}
+          delay={80}
+          className="font-serif text-[64px] leading-[0.95] tracking-tight mb-2"
+        />
+        <TypeReveal
+          text="I’ll ask a few questions and create options for your space."
+          speed={18}
+          delay={620}
+          className="text-[15px] opacity-90"
+        />
 
         {/* (Optional) Hidden semantic heading for SR users */}
         <h2 className="sr-only" id="intake-choose-heading">

--- a/components/motion/TypeReveal.tsx
+++ b/components/motion/TypeReveal.tsx
@@ -1,0 +1,84 @@
+"use client";
+
+import { useEffect, useMemo, useRef, useState } from "react";
+
+/**
+ * TypeReveal — accessible typewriter effect that respects prefers-reduced-motion.
+ * - Renders instantly for reduced motion.
+ * - Uses aria-live="polite" to announce once without spamming SRs.
+ */
+export default function TypeReveal({
+  text,
+  as: Tag = "p",
+  className,
+  speed = 22,        // ms per character
+  delay = 160,       // initial delay
+  showCaret = true,  // blinking caret while typing
+}: {
+  text: string;
+  as?: any;
+  className?: string;
+  speed?: number;
+  delay?: number;
+  showCaret?: boolean;
+}) {
+  const reduced = usePrefersReducedMotion();
+  const [out, setOut] = useState<string>(reduced ? text : "");
+  const doneRef = useRef<boolean>(reduced);
+
+  useEffect(() => {
+    if (reduced) return;
+
+    let i = 0;
+    const start = window.setTimeout(function tick() {
+      const id = window.setInterval(() => {
+        i++;
+        setOut(text.slice(0, i));
+        if (i >= text.length) {
+          window.clearInterval(id);
+          doneRef.current = true;
+        }
+      }, speed);
+    }, delay);
+
+    return () => window.clearTimeout(start);
+  }, [text, speed, delay, reduced]);
+
+  const caret = useMemo(() => {
+    if (!showCaret) return null;
+    return (
+      <span
+        aria-hidden
+        className={`inline-block align-baseline translate-y-[1px] w-[1px] h-[1em] ml-[2px] bg-current ${
+          doneRef.current ? "opacity-0" : "type-caret"
+        }`}
+      />
+    );
+  }, [showCaret]);
+
+  return (
+    <Tag className={className} aria-live="polite">
+      {out}
+      {caret}
+      <style jsx>{`
+        @media (prefers-reduced-motion: no-preference) {
+          .type-caret { animation: caret-blink 1s steps(1, end) infinite; }
+          @keyframes caret-blink { 0%, 45% { opacity: 1; } 50%, 100% { opacity: 0; } }
+        }
+      `}</style>
+    </Tag>
+  );
+}
+
+/* tiny hook */
+function usePrefersReducedMotion() {
+  const [prefers, setPrefers] = useState(true);
+  useEffect(() => {
+    const mq = window.matchMedia("(prefers-reduced-motion: reduce)");
+    const update = () => setPrefers(mq.matches);
+    update();
+    mq.addEventListener?.("change", update);
+    return () => mq.removeEventListener?.("change", update);
+  }, []);
+  return prefers;
+}

--- a/styles/brand-surface.css
+++ b/styles/brand-surface.css
@@ -1,0 +1,45 @@
+/* Brand background with subtle motion (respects reduced motion) */
+:root {
+  --colrvia-green: #404934;
+  --colrvia-green-2: #364034;   /* darker stop */
+  --glow-1: rgba(255, 255, 255, 0.06);
+  --glow-2: rgba(255, 255, 255, 0.04);
+  --shadow-wash: rgba(0, 0, 0, 0.22);
+}
+
+.bg-colrvia-surface {
+  /* Base color + layered radial/linear gradients */
+  background-color: var(--colrvia-green);
+  background-image:
+    radial-gradient(1100px 520px at 12% 12%, var(--glow-1), transparent 60%),
+    radial-gradient(800px 420px at 84% 28%, var(--glow-2), transparent 58%),
+    linear-gradient(180deg, var(--colrvia-green) 0%, var(--colrvia-green-2) 100%);
+  background-attachment: fixed;
+  background-size: 120% 120%, 120% 120%, 100% 100%;
+  background-position: 0% 0%, 100% 40%, 50% 100%;
+}
+
+/* Gentle background drift */
+@media (prefers-reduced-motion: no-preference) {
+  .bg-colrvia-surface {
+    animation: colrvia-bg-pan 18s ease-in-out infinite alternate;
+  }
+  @keyframes colrvia-bg-pan {
+    from { background-position: 0% 0%, 100% 40%, 50% 100%; }
+    to   { background-position: 8% 6%, 92% 22%, 50% 94%; }
+  }
+}
+
+/* Optional grain for depth (super subtle) */
+.bg-colrvia-surface:after {
+  content: "";
+  position: fixed;
+  inset: 0;
+  pointer-events: none;
+  opacity: .035;
+  background-image:
+    radial-gradient(1px 1px at 25% 30%, rgba(255,255,255,.6) 0, transparent 1px),
+    radial-gradient(1px 1px at 70% 60%, rgba(0,0,0,.5) 0, transparent 1px);
+  background-size: 150px 150px, 120px 120px;
+  mix-blend-mode: overlay;
+}


### PR DESCRIPTION
## Summary
- add reusable `TypeReveal` component
- add brand background surface and apply to intake page
- animate intake landing hero text with typewriter effect

## Testing
- `npm run lint`
- `npm run typecheck`
- `npm test` *(fails: browserType.launch: Executable doesn't exist; run `npx playwright install`)*

------
https://chatgpt.com/codex/tasks/task_e_689cbebdff6c83228093746545a1d6d6