### PR TITLE
fix: sync package-lock.json with package.json for CI

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -36,7 +36,7 @@
       },
       "devDependencies": {
         "@axe-core/playwright": "^4.9.0",
-        "@playwright/test": "^1.46.0",
+        "@playwright/test": "^1.45.0",
         "@tailwindcss/postcss": "^4.1.11",
         "@testing-library/jest-dom": "^6.6.4",
         "@testing-library/react": "^16.3.0",
@@ -56,7 +56,7 @@
         "service-worker-mock": "^2.0.5",
         "tailwindcss": "^4.1.11",
         "tsx": "^4.19.1",
-        "typescript": "5.3.3",
+        "typescript": "^5.5.4",
         "vitest": "^1.6.0"
       }
     },
@@ -11955,10 +11955,11 @@
       }
     },
     "node_modules/typescript": {
-      "version": "5.3.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.3.3.tgz",
-      "integrity": "sha512-pXWcraxM0uxAS+tN0AG/BF2TyqmHO014Z070UsJ+pFvYuRSq8KH8DmWpnbXe0pEPDHXZV3FcAbJkijJ5oNEnWw==",
+      "version": "5.9.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.2.tgz",
+      "integrity": "sha512-CWBzXQrc/qOkhidw1OzBTQuYRbfyxDXJMVJ1XNwUHGROVmuaeiEm3OslpZ1RV96d7SKKjZKrSJu3+t/xlw3R9A==",
       "devOptional": true,
+      "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"


### PR DESCRIPTION
## Summary
- align package-lock.json with package.json to resolve TypeScript version mismatch

## Testing
- `npm test` *(fails: page.goto net::ERR_CONNECTION_REFUSED)*

------
https://chatgpt.com/codex/tasks/task_e_689cc2134a3883229df0d4d02761f8cb