### PR TITLE
Gate 3D card effects to mouse pointers

### DIFF
--- a/styles/card-motion.css
+++ b/styles/card-motion.css
@@ -1,0 +1,11 @@
+@media (hover: hover) and (pointer: fine) {
+  .card-3d {
+    transition:
+      transform 220ms cubic-bezier(.2,.8,.2,1),
+      box-shadow 220ms cubic-bezier(.2,.8,.2,1),
+      background-color 180ms ease;
+  }
+}
+@media (hover: none), (pointer: coarse) {
+  .card-3d { transform: none !important; }
+}


### PR DESCRIPTION
## Summary
- add media queries to enable card tilt only on hoverable fine pointers
- restrict ModeCard tilt logic to mouse events and media query

## Testing
- `npm test` *(fails: net::ERR_CONNECTION_REFUSED at http://localhost:3000)*
- `npm run lint`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_689cc3a2b7d883228deec9d29c2f6a46