### PR TITLE
Redirect therapist preferences to intake

### DIFF
--- a/app/(shell)/start/preferences/page.tsx
+++ b/app/(shell)/start/preferences/page.tsx
@@ -5,10 +5,14 @@ import { useEffect } from 'react'
 export default function PreferencesAlias(){
   const sp = useSearchParams()
   const router = useRouter()
-  useEffect(()=>{
+  useEffect(() => {
     const d = sp.get('designerId')
-  if (d) router.replace(`/preferences/${d}`)
-    else router.replace('/designers')
-  },[sp, router])
+    if (d) {
+      if (d === 'therapist') router.replace('/intake')
+      else router.replace(`/preferences/${d}`)
+    } else {
+      router.replace('/designers')
+    }
+  }, [sp, router])
   return <main className="px-4 py-12 text-sm text-muted-foreground">Loading preferences…</main>
 }

--- a/app/preferences/[designerId]/page.tsx
+++ b/app/preferences/[designerId]/page.tsx
@@ -3,11 +3,13 @@ import { getDesigner, DEFAULT_DESIGNER_ID, isDesignerLocked } from '@/lib/ai/des
 import { getUserTier } from '@/lib/profile'
 import Link from 'next/link'
 import { UpgradeButton } from '@/components/paywall/UpgradeButton'
+import { redirect } from 'next/navigation'
 
 export const dynamic = 'force-dynamic'
 
 export default async function PreferencesPage({ params }: { params:{ designerId:string } }){
   const id = (params.designerId || '').toLowerCase()
+  if (id === 'therapist') redirect('/intake')
   const designer = getDesigner(id)
   if(!designer) return <div className="p-10">Designer not found.</div>
   const { tier, user } = await getUserTier()

--- a/app/sitemap.ts
+++ b/app/sitemap.ts
@@ -3,6 +3,6 @@ export default function sitemap(): MetadataRoute.Sitemap {
   const base = process.env.NEXT_PUBLIC_SITE_URL ?? "https://example.com";
   return [
     { url: `${base}/`, changeFrequency: "weekly", priority: 1 },
-    { url: `${base}/preferences/therapist`, changeFrequency: "monthly", priority: 0.8 },
+    { url: `${base}/intake`, changeFrequency: "monthly", priority: 0.8 },
   ];
 }

--- a/components/DesignerCard.tsx
+++ b/components/DesignerCard.tsx
@@ -10,7 +10,7 @@ export default function DesignerCard({ d }: { d: DesignerProfile }) {
       <div className="text-neutral-600">{d.tagline}</div>
       <div className="text-neutral-500 text-sm mt-2">{d.style}</div>
       <Link
-        href={d.id === 'therapist' ? '/preferences/therapist' : `/preferences/${d.id}`}
+        href={d.id === 'therapist' ? '/intake' : `/preferences/${d.id}`}
         className="inline-block mt-4 rounded-xl px-4 py-2 bg-black text-white"
       >
         Choose {d.name.split(' ')[0]}

--- a/components/ai/DesignersGrid.tsx
+++ b/components/ai/DesignersGrid.tsx
@@ -18,7 +18,7 @@ export default function DesignersGrid(){
           <div className="mt-auto">
           <Button
               as={Link}
-              href={d.id === 'therapist' ? '/preferences/therapist' : `/preferences/${d.id}`}
+              href={d.id === 'therapist' ? '/intake' : `/preferences/${d.id}`}
               className="w-full"
               onClick={() => track('designer_select', { designerId: d.id })}
               aria-label={`Start with ${d.name}`}

--- a/e2e/intake-flow.pw.ts
+++ b/e2e/intake-flow.pw.ts
@@ -22,8 +22,8 @@ test.describe("Intake flow", () => {
     await page.goto("/designers")
     await page.getByRole("link", { name: /start with color therapist/i }).click()
 
-    await expect(page).toHaveURL(/\/preferences\/therapist$/)
-    await expect(page.getByText("Which room?")).toBeVisible()
+    await expect(page).toHaveURL(/\/intake$/)
+    await expect(page.getByRole("button", { name: /start voice chat/i })).toBeVisible()
   })
 
   test("unauthenticated reveal round-trips through sign-in", async ({ page }) => {
@@ -70,12 +70,14 @@ test.describe("Intake flow", () => {
       }
     })
 
-    await page.goto("/preferences/therapist")
+    await page.goto("/intake")
+    await page.getByRole("button", { name: /start voice chat/i }).click()
     await page.getByRole("button", { name: /sherwin/i }).click()
 
     await expect(page).toHaveURL(/\/sign-in$/)
 
-    await page.goto("/preferences/therapist")
+    await page.goto("/intake")
+    await page.getByRole("button", { name: /start voice chat/i }).click()
     await page.getByRole("button", { name: /sherwin/i }).click()
 
     await expect(page).toHaveURL(/\/reveal\/story-123/)

--- a/tests/a11y.smoke.spec.ts
+++ b/tests/a11y.smoke.spec.ts
@@ -1,7 +1,7 @@
 import { test, expect } from "@playwright/test";
 import AxeBuilder from "@axe-core/playwright";
 test("intake page a11y smoke", async ({ page }) => {
-  await page.goto("/preferences/therapist");
+  await page.goto("/intake");
   const { violations } = await new AxeBuilder({ page }).analyze();
   expect(violations.filter(v => v.impact === "critical")).toEqual([]);
 });


### PR DESCRIPTION
## Summary
- redirect legacy therapist preferences route to intake
- update designer selection links and sitemap
- adjust Playwright tests for new intake path

## Testing
- `npx playwright install-deps`
- `npm test`
- `npm run lint`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_689cc4e380a48322ae5ad7a2d598d65c