### PR TITLE
Add Moss onboarding flow with conversational interview

### DIFF
--- a/app/(shell)/home/page.tsx
+++ b/app/(shell)/home/page.tsx
@@ -6,13 +6,13 @@ export default function HomeShell(){
     <main className="max-w-3xl mx-auto px-4 py-12 space-y-10">
       <header>
         <h1 className="font-display text-4xl leading-[1.05] mb-4">Start color story</h1>
-  <p className="text-sm text-muted-foreground max-w-md">Three quick steps: pick a designer, share a few preferences, preview your palette.</p>
+        <p className="text-sm text-muted-foreground max-w-md">Designer-led conversation · ~6 minutes · 6–8 quick questions.</p>
       </header>
       <div className="space-y-6">
-        <Link href="/designers" className="btn btn-primary w-full sm:w-auto">Start color story</Link>
+        <Link href="/start/interview-intro" className="btn btn-primary w-full sm:w-auto">Start color story</Link>
         <div className="grid gap-4 sm:grid-cols-2">
           <Link href="/discover" className="card p-6 hover:shadow-md transition-shadow"><h2 className="font-semibold mb-2">Discover color stories</h2><p className="text-sm text-muted-foreground">Explore recent palettes & reveals.</p></Link>
-          <Link href="/designers" className="card p-6 hover:shadow-md transition-shadow"><h2 className="font-semibold mb-2">Meet our designers</h2><p className="text-sm text-muted-foreground">Choose a style lens to guide your picks.</p></Link>
+          <Link href="/how-it-works" className="card p-6 hover:shadow-md transition-shadow"><h2 className="font-semibold mb-2">How it works</h2><p className="text-sm text-muted-foreground">See the process end to end.</p></Link>
         </div>
       </div>
     </main>

--- a/app/(shell)/start/interview-intro/page.tsx
+++ b/app/(shell)/start/interview-intro/page.tsx
@@ -1,0 +1,12 @@
+import React from "react";
+import Link from "next/link";
+
+export default function InterviewIntro() {
+  return (
+    <main className="max-w-xl mx-auto px-4 py-12 space-y-8 text-center">
+      <h1 className="font-display text-4xl mb-4">Designer interview</h1>
+      <p className="text-sm text-muted-foreground">Designer-led conversation · ~6 minutes · 6–8 quick questions.</p>
+      <Link href="/start/interview" className="btn btn-primary mt-6">Start interview</Link>
+    </main>
+  );
+}

--- a/app/(shell)/start/interview/page.tsx
+++ b/app/(shell)/start/interview/page.tsx
@@ -1,0 +1,91 @@
+"use client";
+import React, { useEffect, useState } from "react";
+import { useRouter } from "next/navigation";
+import useOnboardingFlow from "@/lib/hooks/useOnboardingFlow";
+import { moss } from "@/lib/ai/phrasing";
+import { QUESTION_SECTIONS } from "@/lib/ai/sections";
+
+export default function InterviewPage() {
+  const router = useRouter();
+  const { state, currentQ, sendAnswer, done } = useOnboardingFlow();
+  const [input, setInput] = useState("");
+
+  useEffect(() => {
+    if (done) router.push("/start/processing");
+  }, [done, router]);
+
+  if (!currentQ) {
+    return <main className="p-8">{moss.greet()}</main>;
+  }
+
+  const answeredKeys = Object.keys(state?.answers || {});
+  const sectionTotals = Object.entries(QUESTION_SECTIONS).reduce(
+    (acc, [id, sec]) => {
+      acc[sec] = (acc[sec] || 0) + 1;
+      return acc;
+    },
+    { style: 0, room: 0 } as Record<string, number>
+  );
+  const answeredCounts = answeredKeys.reduce(
+    (acc, k) => {
+      const sec = (QUESTION_SECTIONS as any)[k];
+      if (sec) acc[sec] = (acc[sec] || 0) + 1;
+      return acc;
+    },
+    { style: 0, room: 0 } as Record<string, number>
+  );
+  const currentSection = (QUESTION_SECTIONS as any)[currentQ.key] as "style" | "room";
+  const label = moss.progressLabel(
+    currentSection,
+    (answeredCounts as any)[currentSection] + 1,
+    (sectionTotals as any)[currentSection]
+  );
+
+  async function submit() {
+    if (!input) return;
+    const val = input;
+    setInput("");
+    await sendAnswer(val);
+  }
+
+  return (
+    <main className="max-w-xl mx-auto px-4 py-8 space-y-6">
+      <p className="text-sm text-muted-foreground">{moss.greet()}</p>
+      <div>
+        <p className="mb-2">{moss.ask(currentQ.prompt)}</p>
+        {Array.isArray(currentQ.options) && currentQ.options.length > 0 && (
+          <div className="flex flex-wrap gap-2 mb-2">
+            {currentQ.options.map((o) => (
+              <button
+                key={o}
+                type="button"
+                className="chip"
+                onClick={() => sendAnswer(o)}
+              >
+                {o}
+              </button>
+            ))}
+          </div>
+        )}
+        <input
+          value={input}
+          onChange={(e) => setInput(e.target.value)}
+          onKeyDown={(e) => {
+            if (e.key === "Enter") submit();
+          }}
+          placeholder={moss.typingHint()}
+          className="w-full rounded border px-3 py-2"
+        />
+        <button
+          type="button"
+          className="btn btn-primary mt-3"
+          onClick={submit}
+          disabled={!input}
+        >
+          Send
+        </button>
+      </div>
+      <div className="text-xs text-muted-foreground">{label}</div>
+    </main>
+  );
+}

--- a/app/(shell)/start/processing/page.tsx
+++ b/app/(shell)/start/processing/page.tsx
@@ -1,0 +1,21 @@
+"use client";
+import React, { useEffect } from "react";
+import { useRouter } from "next/navigation";
+import { moss } from "@/lib/ai/phrasing";
+import { createPaletteFromInterview } from "@/lib/palette";
+
+export default function ProcessingPage() {
+  const router = useRouter();
+  useEffect(() => {
+    (async () => {
+      const { id } = await createPaletteFromInterview();
+      router.replace(`/reveal/${id}`);
+    })();
+  }, [router]);
+
+  return (
+    <main className="max-w-xl mx-auto px-4 py-20 text-center">
+      <p>{moss.working()}</p>
+    </main>
+  );
+}

--- a/lib/ai/phrasing.ts
+++ b/lib/ai/phrasing.ts
@@ -85,3 +85,14 @@ export function buildStartUtterance(designerId: string, rngSeed: string, firstPr
 export function buildNextUtterance(ack: string, nextPrompt: string){
   return `${ack} ${nextPrompt}`
 }
+
+export const moss = {
+  greet: () => "Hey, I’m Moss—your personal paint matchmaker 🌿 Let’s craft something that feels like you.",
+  ask: (corePrompt: string) => `Okay, quick one—${corePrompt}`,
+  empathize: (ack: string) => `${ack} Love that direction.`,
+  typingHint: () => "You can just type—I'll keep it breezy.",
+  progressLabel: (section: "style"|"room", i: number, total: number) => `${section === "style" ? "Style" : "Room"} ${i}/${total}`,
+  working: () => "Balancing light, undertones, and your vibe… one sec while I blend 🎨",
+  revealTitle: (ctx: string) => `Moss’s palette for your ${ctx}`,
+  teaserOtherDesigners: () => "Curious how another eye would tune this? Try other designers’ takes.",
+};

--- a/lib/ai/sections.ts
+++ b/lib/ai/sections.ts
@@ -1,0 +1,10 @@
+export const QUESTION_SECTIONS: Record<string, "style" | "room"> = {
+  space: "room",
+  lighting: "room",
+  vibe: "style",
+  contrast: "style",
+  fixed: "room",
+  avoid: "style",
+  trim: "room",
+  brand: "style",
+};

--- a/lib/hooks/useOnboardingFlow.ts
+++ b/lib/hooks/useOnboardingFlow.ts
@@ -1,0 +1,52 @@
+'use client';
+import { useEffect, useState } from 'react';
+import { type InterviewState, getCurrentNode } from '@/lib/ai/onboardingGraph';
+
+interface FlowReturn {
+  state: InterviewState | null;
+  currentQ: ReturnType<typeof getCurrentNode> | null;
+  sendAnswer: (val: string) => Promise<void>;
+  done: boolean;
+}
+
+export default function useOnboardingFlow(): FlowReturn {
+  const [state, setState] = useState<InterviewState | null>(null);
+  const [currentQ, setCurrentQ] = useState<ReturnType<typeof getCurrentNode> | null>(null);
+  const [done, setDone] = useState(false);
+  const designerId = 'therapist';
+
+  useEffect(() => {
+    let active = true;
+    (async () => {
+      try {
+        const r = await fetch('/api/ai/preferences', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ designerId, step: 'start' })
+        });
+        const j = await r.json().catch(() => null);
+        if (!active) return;
+        setState(j?.state ?? null);
+        setCurrentQ(j?.state ? getCurrentNode(j.state) : null);
+      } catch {}
+    })();
+    return () => { active = false; };
+  }, []);
+
+  async function sendAnswer(val: string) {
+    if (!state || done) return;
+    try {
+      const r = await fetch('/api/ai/preferences', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ designerId, step: 'answer', content: val, state })
+      });
+      const j = await r.json().catch(() => null);
+      setState(j?.state ?? null);
+      setCurrentQ(j?.state ? getCurrentNode(j.state) : null);
+      if (j?.state?.done) setDone(true);
+    } catch {}
+  }
+
+  return { state, currentQ, sendAnswer, done };
+}

--- a/lib/palette.ts
+++ b/lib/palette.ts
@@ -101,3 +101,10 @@ export function decodePalette(value: unknown): DecodedSwatch[] {
   }
   return []
 }
+
+// Placeholder palette creation from interview answers.
+// In production this would call backend services to persist a palette
+// and return its identifier. For tests we simply return a mock id.
+export async function createPaletteFromInterview() {
+  return { id: 'mock' };
+}

--- a/tests/ai/onboarding-api-flow.test.tsx
+++ b/tests/ai/onboarding-api-flow.test.tsx
@@ -1,0 +1,39 @@
+import React from "react";
+import { describe, it, expect, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import InterviewIntro from "@/app/(shell)/start/interview-intro/page";
+import ProcessingPage from "@/app/(shell)/start/processing/page";
+import InterviewPage from "@/app/(shell)/start/interview/page";
+import { moss } from "@/lib/ai/phrasing";
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ push: vi.fn(), replace: vi.fn() })
+}));
+
+// Mock hook to supply deterministic question
+vi.mock("@/lib/hooks/useOnboardingFlow", () => ({
+  default: () => ({
+    state: { answers: {} },
+    currentQ: { key: "space", prompt: "Which space are we working on?", options: ["Living room"] },
+    sendAnswer: vi.fn(),
+    done: false
+  })
+}));
+
+describe("onboarding flow pages", () => {
+  it("renders interview intro", () => {
+    render(<InterviewIntro />);
+    expect(screen.getByText(/Designer interview/i)).toBeTruthy();
+  });
+
+  it("shows processing message", () => {
+    render(<ProcessingPage />);
+    expect(screen.getByText(moss.working())).toBeTruthy();
+  });
+
+  it("shows moss greeting and progress label", () => {
+    render(<InterviewPage />);
+    expect(screen.getByText(moss.greet())).toBeTruthy();
+    expect(screen.getByText(/Room 1\/4/)).toBeTruthy();
+  });
+});

--- a/tests/api/ai-onboarding.test.ts
+++ b/tests/api/ai-onboarding.test.ts
@@ -1,4 +1,6 @@
 import { describe, it, expect } from 'vitest'
+import { nodes } from '@/lib/ai/onboardingGraph'
+import { QUESTION_SECTIONS } from '@/lib/ai/sections'
 
 describe('POST /api/ai/onboarding', () => {
   it('works without OPENAI_API_KEY (fallback phrasing)', async () => {
@@ -13,5 +15,11 @@ describe('POST /api/ai/onboarding', () => {
   expect(json.state).toBeTruthy()
   expect(typeof json.utterance).toBe('string')
   expect(typeof json.state.rngSeed).toBe('string')
+  })
+
+  it('maps all questions to a section', () => {
+    nodes.forEach(n => {
+      expect(QUESTION_SECTIONS[n.key]).toBeTruthy()
+    })
   })
 })


### PR DESCRIPTION
## Summary
- add Moss phrasing helpers and question section mapping
- introduce Moss interview intro, interview, and processing routes
- wire onboarding flow with progress labels and simple tests

## Testing
- `npx vitest run tests/api/ai-onboarding.test.ts tests/ai/onboarding-api-flow.test.tsx`

------
https://chatgpt.com/codex/tasks/task_e_689ce26a2dc88322aadd7b36ac1b441d