### PR TITLE
Direct Start Color Story CTA to interview intro

### DIFF
--- a/app/first-run/welcome/page.tsx
+++ b/app/first-run/welcome/page.tsx
@@ -13,7 +13,7 @@ export default function FirstRunWelcome(){
         <h1 className="font-display text-4xl leading-[1.05]">Design calmer, faster.</h1>
   <p className="text-sm text-muted-foreground">Turn a vibe into real paints with placement guidance. No account needed until you save.</p>
         <div className="space-y-3">
-          <Link href="/designers" onClick={setDone} className="btn btn-primary w-full">Start color story</Link>
+          <Link href="/start/interview-intro" onClick={setDone} className="btn btn-primary w-full">Start color story</Link>
           <Link href="/sign-in" onClick={()=>{ setDone(); }} className="btn btn-secondary w-full">Sign in</Link>
           <button type="button" onClick={()=>{ setDone(); router.push('/home') }} className="btn btn-ghost w-full">Skip for now</button>
         </div>

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -46,8 +46,8 @@ export default function HomePage() {
         </header>
         <div className="mt-8">
           <Link
-            href="/designers"
-            onClick={(e) => { e.preventDefault(); startStory("/designers") }}
+            href="/start/interview-intro"
+            onClick={(e) => { e.preventDefault(); startStory("/start/interview-intro") }}
             className="inline-flex items-center justify-center rounded-2xl px-8 py-4 text-xl md:text-2xl font-semibold w-full sm:w-auto hover:opacity-95"
             style={{ backgroundColor: "#f2b897", color: "#1f2937" }}
           >

--- a/components/marketing/HowItWorksContent.tsx
+++ b/components/marketing/HowItWorksContent.tsx
@@ -36,7 +36,7 @@ export default function HowItWorksContent({ compact = false }: { compact?: boole
             </li>
           </ol>
           <div className="mt-5">
-            <Button as={Link} href="/designers" variant="primary" onClick={() => track('howitworks_start', { where: compact ? 'modal' : 'page' })}>Start Color Story</Button>
+            <Button as={Link} href="/start/interview-intro" variant="primary" onClick={() => track('howitworks_start', { where: compact ? 'modal' : 'page' })}>Start Color Story</Button>
           </div>
         </div>
         <div className="order-1 md:order-2">

--- a/components/marketing/HowItWorksModal.tsx
+++ b/components/marketing/HowItWorksModal.tsx
@@ -43,7 +43,7 @@ export default function HowItWorksModal({ open, onOpenChange, origin='unknown' }
         <div className="overflow-auto pr-1">
           <HowItWorksContent compact />
           <div className="mt-6">
-            <Button as={"a"} href="/designers" variant="primary" onClick={()=>{ const ms = timer.peek(); try { track('howitworks_start', { where:'modal', origin, ms }) } catch {} }}>Start Color Story</Button>
+            <Button as={"a"} href="/start/interview-intro" variant="primary" onClick={()=>{ const ms = timer.peek(); try { track('howitworks_start', { where:'modal', origin, ms }) } catch {} }}>Start Color Story</Button>
           </div>
         </div>
       </DialogContent>


### PR DESCRIPTION
## Summary
- Route Home page "Start Color Story" CTA to `/start/interview-intro`
- Update first-run and marketing Start CTA links to point to the same interview intro flow

## Testing
- `npm test` *(fails: net::ERR_CONNECTION_REFUSED at http://localhost:3000/reveal/tmp_test?optimistic=1)*
- `npx vitest run` *(fails: tests/layout-skip-link.test.tsx)*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689ce9b5d2888322a6da9100c63569e7