### PR TITLE
feat: reorder intake question queue by section

### DIFF
--- a/lib/intake/engine.ts
+++ b/lib/intake/engine.ts
@@ -1,4 +1,5 @@
 import { Answers } from './types';
+import { getSection } from './sections';
 
 function pushIfUnanswered(q: string[], a: Answers, id: string) {
   if (a[id] === undefined) q.push(id);
@@ -86,5 +87,10 @@ export function buildQuestionQueue(a: Answers): string[] {
   if (hasColorRules(a)) q.push('avoid_colors');
 
   capByPriority(q, a);
-  return q;
+  const style: string[] = [];
+  const room: string[] = [];
+  for (const id of q) {
+    (getSection(id) === 'style' ? style : room).push(id);
+  }
+  return [...style, ...room];
 }

--- a/lib/intake/sections.ts
+++ b/lib/intake/sections.ts
@@ -1,4 +1,6 @@
-export const QUESTION_SECTIONS: Record<string, 'style' | 'room'> = {
+export type Section = 'style' | 'room'
+
+export const QUESTION_SECTIONS: Record<string, Section> = {
   style_primary: 'style',
   mood_words: 'style',
   dark_stance: 'style',
@@ -9,7 +11,7 @@ export const QUESTION_SECTIONS: Record<string, 'style' | 'room'> = {
 };
 
 // Helper for ids not explicitly listed: modules like K*, B*, L*, N*, H*, O*, C* are all room
-export function getSection(id: string): 'style' | 'room' {
+export function getSection(id: string): Section {
   return (
     QUESTION_SECTIONS[id] || (/^[KBLNHOC]/.test(id) ? 'room' : 'style')
   );

--- a/tests/lib/intake/engine.test.ts
+++ b/tests/lib/intake/engine.test.ts
@@ -1,9 +1,18 @@
 import { buildQuestionQueue, capByPriority } from '@/lib/intake/engine'
+import { getSection } from '@/lib/intake/sections'
 
 describe('buildQuestionQueue', () => {
-  it('orders style questions before room questions', () => {
-    const q = buildQuestionQueue({})
-    expect(q.slice(0,4)).toEqual(['style_primary','mood_words','dark_stance','room_type'])
+  it('reordered queue groups style before room', () => {
+    const q = buildQuestionQueue({
+      dark_stance: 'walls',
+      light_level: 'varies',
+      room_type: 'kitchen',
+      constraints: ['color_rules'],
+    })
+    const firstRoom = q.findIndex(id => getSection(id) === 'room')
+    expect(firstRoom).toBeGreaterThan(-1)
+    expect(q.slice(0, firstRoom).every(id => getSection(id) === 'style')).toBe(true)
+    expect(q.slice(firstRoom).every(id => getSection(id) === 'room')).toBe(true)
   })
 
   it('includes dark_locations when stance triggers', () => {
@@ -13,7 +22,7 @@ describe('buildQuestionQueue', () => {
 })
 
 describe('capByPriority', () => {
-  it('drops items in priority order to enforce cap', () => {
+  it('cap drop order unchanged', () => {
     const q = ['style_primary','mood_words','dark_stance','dark_locations','room_type','light_level','window_aspect','K1','K1a','B1a','L1a','O2','constraints','avoid_colors','adjacent_primary_color','extra1','extra2']
     capByPriority(q, {})
     expect(q.length).toBe(15)


### PR DESCRIPTION
## Summary
- add Section mapping for intake questions
- reorder buildQuestionQueue output to group style before room
- test that queue ordering and capping logic remain consistent

## Testing
- `npx vitest run tests/lib/intake/engine.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_689d0e48e52c8322b09d42f978c2756e