### PR TITLE
feat: add voice interview shell components

### DIFF
--- a/app/(shell)/start/interview/page.tsx
+++ b/app/(shell)/start/interview/page.tsx
@@ -1,3 +1,5 @@
+import VoiceInterview from '@/components/voice/VoiceInterview'
+
 export default function InterviewPage() {
-  return <div data-testid="voice-shell">Voice shell</div>
+  return <VoiceInterview />
 }

--- a/components/ai/ChatCaptions.tsx
+++ b/components/ai/ChatCaptions.tsx
@@ -1,0 +1,17 @@
+'use client'
+
+type ChatCaptionsProps = {
+  text: string
+}
+
+export default function ChatCaptions({ text }: ChatCaptionsProps) {
+  return (
+    <p
+      aria-live="polite"
+      className="h-5 w-full overflow-hidden text-ellipsis whitespace-nowrap text-center text-sm text-ink-subtle"
+    >
+      {text}
+    </p>
+  )
+}
+

--- a/components/voice/MicButton.tsx
+++ b/components/voice/MicButton.tsx
@@ -1,7 +1,26 @@
 'use client'
 
-export default function MicButton() {
-  return (
-    <button type="button" aria-label="mic" className="mic-button">🎙️</button>
-  );
+import { Mic } from 'lucide-react'
+
+type MicButtonProps = {
+  onClick?: () => void
+  isListening?: boolean
 }
+
+export default function MicButton({ onClick, isListening }: MicButtonProps) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      className="flex flex-col items-center gap-2"
+    >
+      <span className="flex h-24 w-24 items-center justify-center rounded-full bg-brand text-brand-contrast">
+        <Mic className="h-10 w-10" />
+      </span>
+      <span className="text-sm font-medium">
+        {isListening ? 'Listening…' : 'Tap to answer'}
+      </span>
+    </button>
+  )
+}
+

--- a/components/voice/VoiceInterview.tsx
+++ b/components/voice/VoiceInterview.tsx
@@ -1,30 +1,68 @@
 'use client'
 
-import React, { useEffect } from 'react'
-import { buildQuestionQueue } from '@/lib/intake/engine'
+import { useEffect, useState } from 'react'
+import ChatCaptions from '@/components/ai/ChatCaptions'
+import MicButton from './MicButton'
 import { moss } from '@/lib/ai/phrasing'
-import { speak } from '@/lib/voice/session'
-import { nluParse } from '@/lib/intake/nlu'
+import { listenOnce, speak, startVoiceSession } from '@/lib/voice/session'
 
 export default function VoiceInterview() {
-  const answers: Record<string, any> = {}
-  const queue = buildQuestionQueue(answers)
-  const currentId = queue[0]
+  const [activeSection] = useState<'style' | 'room'>('style')
+  const [currentQuestion] = useState('How would you describe your style?')
+  const [captions, setCaptions] = useState('')
+  const [isListening, setIsListening] = useState(false)
 
   useEffect(() => {
-    if (!currentId) return
-    speak(moss.ask(currentId))
-  }, [currentId])
+    startVoiceSession()
+    speak(moss.greet())
+  }, [])
 
-  async function onTranscript(text: string) {
-    const normalized = nluParse(currentId, text)
-    answers[currentId] = normalized
+  async function handleMic() {
+    setIsListening(true)
+    const text = await listenOnce()
+    setCaptions(text)
+    setIsListening(false)
   }
 
   return (
-    <div className="voice-shell">
-      <p>{moss.greet()}</p>
-      <span>Room 1/4</span>
+    <div className="mx-auto flex max-w-md flex-col items-center gap-6 p-4">
+      <header className="w-full text-center">
+        <div className="flex flex-col items-center gap-2">
+          <div className="h-12 w-12 rounded-full bg-brand" />
+          <h2 className="text-lg font-medium">Moss</h2>
+        </div>
+        <div className="mt-4 flex justify-center gap-2">
+          <span
+            className={`rounded-full px-3 py-1 text-sm ${
+              activeSection === 'style'
+                ? 'bg-brand text-brand-contrast'
+                : 'border border-ink-subtle text-ink-subtle'
+            }`}
+          >
+            Style
+          </span>
+          <span
+            className={`rounded-full px-3 py-1 text-sm ${
+              activeSection === 'room'
+                ? 'bg-brand text-brand-contrast'
+                : 'border border-ink-subtle text-ink-subtle'
+            }`}
+          >
+            Room
+          </span>
+        </div>
+      </header>
+
+      <main className="flex flex-col items-center gap-4">
+        <p className="mt-2 text-center text-base">{currentQuestion}</p>
+        <MicButton onClick={handleMic} isListening={isListening} />
+        <button type="button" className="text-sm text-ink-subtle">
+          Not sure
+        </button>
+      </main>
+
+      <ChatCaptions text={captions} />
     </div>
   )
 }
+


### PR DESCRIPTION
## Summary
- scaffold voice interview UI with moss header and voice controls
- add mic button, chat captions components
- mount interview shell in start flow

## Testing
- `npm test` *(fails: Host system is missing dependencies to run browsers)*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689d11b45dd48322ba99ba5c24db3278