### PR TITLE
feat(intake): add nlu parsing

### DIFF
--- a/lib/intake/nlu.ts
+++ b/lib/intake/nlu.ts
@@ -1,4 +1,106 @@
-export function nluParse(id: string, text: string): any {
-  // Placeholder normalizer; real implementation would map synonyms to enums
-  return text.trim();
+const NOT_SURE = [
+  'not sure',
+  "don't know",
+  'dont know',
+  'unsure',
+  'no idea',
+];
+
+function isNotSure(text: string): boolean {
+  const t = text.toLowerCase();
+  return NOT_SURE.some(p => t.includes(p));
 }
+
+function mapFromSynonyms(map: Record<string, string[]>, text: string): string | undefined {
+  let match: { key: string; len: number } | null = null;
+  for (const [key, synonyms] of Object.entries(map)) {
+    for (const s of synonyms) {
+      if (text.includes(s) && (!match || s.length > match.len)) {
+        match = { key, len: s.length };
+      }
+    }
+  }
+  return match?.key;
+}
+
+const STYLE_SYNONYMS: Record<string, string[]> = {
+  modern: ['modern', 'minimal', 'minimalist', 'contemporary'],
+  cottage: ['cottage', 'farmhouse', 'rustic'],
+  traditional: ['traditional', 'classic'],
+  japandi: ['japandi'],
+  scandinavian: ['scandinavian', 'nordic'],
+  industrial: ['industrial'],
+  bohemian: ['bohemian', 'boho'],
+  coastal: ['coastal', 'beach', 'beachy'],
+  midcentury: ['mid century', 'mid-century', 'midcentury'],
+  transitional: ['transitional'],
+  mix: ['mix', 'eclectic'],
+};
+
+const LIGHT_SYNONYMS: Record<string, string[]> = {
+  bright: ['bright', 'lots of light', 'sunny', 'well lit', 'tons of light'],
+  low: ['low', 'dim', 'dark', 'not much light'],
+  varies: ['varies', 'mixed', 'depends', 'changes', 'average'],
+};
+
+const STANCE_SYNONYMS: Record<string, string[]> = {
+  avoid: ['avoid', 'no dark', 'keep it light', 'none', 'no dark colors'],
+  walls: ['walls', 'wall', 'feature wall'],
+  accents: ['accents', 'accent', 'trim only', 'just trim'],
+  open: ['open', 'anywhere', 'wherever', 'designer choice', 'do whatever'],
+};
+
+const LOCATION_SYNONYMS: Record<string, string[]> = {
+  walls: ['wall', 'walls', 'feature wall', 'accent wall'],
+  trim: ['trim', 'baseboard', 'molding'],
+  ceiling: ['ceiling', 'ceilings'],
+  cabinetry: ['cabinet', 'cabinets', 'cabinetry', 'built-in', 'builtin', 'builtins'],
+  doors: ['door', 'doors'],
+  island: ['island'],
+};
+
+export function nluParse(id: string, transcript: string): any {
+  const text = transcript.trim().toLowerCase();
+
+  if (isNotSure(text)) {
+    if (id === 'window_aspect') return 'unknown';
+    if (id === 'dark_stance') return 'open';
+    if (id.includes('detail')) return 'unsure';
+  }
+
+  switch (id) {
+    case 'style_primary': {
+      return mapFromSynonyms(STYLE_SYNONYMS, text) || (isNotSure(text) ? 'mix' : text);
+    }
+    case 'light_level': {
+      return mapFromSynonyms(LIGHT_SYNONYMS, text) || text;
+    }
+    case 'dark_stance': {
+      return mapFromSynonyms(STANCE_SYNONYMS, text) || text;
+    }
+    case 'dark_locations': {
+      const locs: string[] = [];
+      for (const [key, synonyms] of Object.entries(LOCATION_SYNONYMS)) {
+        if (synonyms.some(s => text.includes(s))) locs.push(key);
+      }
+      if (locs.length) return Array.from(new Set(locs));
+      if (isNotSure(text)) return ['designer_suggest'];
+      return text.split(/[^a-z]+/).filter(Boolean);
+    }
+    case 'mood_words': {
+      return text.split(/[^a-z]+/).filter(Boolean).slice(0, 3);
+    }
+    case 'window_aspect': {
+      const MAP: Record<string, string[]> = {
+        north: ['north', 'north-facing', 'north facing'],
+        south: ['south', 'south-facing', 'south facing'],
+        east: ['east', 'east-facing', 'east facing'],
+        west: ['west', 'west-facing', 'west facing'],
+      };
+      return mapFromSynonyms(MAP, text) || 'unknown';
+    }
+    default:
+      return text;
+  }
+}
+

--- a/tests/lib/intake/nlu.test.ts
+++ b/tests/lib/intake/nlu.test.ts
@@ -1,0 +1,35 @@
+import { nluParse } from '@/lib/intake/nlu'
+
+describe('nluParse', () => {
+  it('maps style synonyms', () => {
+    expect(nluParse('style_primary', 'Mid century modern')).toBe('midcentury')
+  })
+
+  it('maps light level synonyms', () => {
+    expect(nluParse('light_level', 'lots of light')).toBe('bright')
+    expect(nluParse('light_level', 'pretty dim')).toBe('low')
+    expect(nluParse('light_level', 'changes through day')).toBe('varies')
+  })
+
+  it('maps dark stance synonyms', () => {
+    expect(nluParse('dark_stance', 'no dark colors')).toBe('avoid')
+    expect(nluParse('dark_stance', 'accents only')).toBe('accents')
+    expect(nluParse('dark_stance', 'do it anywhere')).toBe('open')
+    expect(nluParse('dark_stance', 'one feature wall')).toBe('walls')
+  })
+
+  it('maps dark location synonyms', () => {
+    expect(nluParse('dark_locations', 'the trim and island')).toEqual(['trim', 'island'])
+    expect(nluParse('dark_locations', 'feature wall')).toEqual(['walls'])
+  })
+
+  it('limits mood words to three', () => {
+    expect(nluParse('mood_words', 'airy calm cozy bright')).toEqual(['airy', 'calm', 'cozy'])
+  })
+
+  it('handles not sure defaults', () => {
+    expect(nluParse('window_aspect', 'not sure')).toBe('unknown')
+    expect(nluParse('dark_stance', 'not sure')).toBe('open')
+    expect(nluParse('fixed_details', 'not sure')).toBe('unsure')
+  })
+})


### PR DESCRIPTION
## Summary
- map user transcripts to canonical enums for intake
- default uncertain replies for window aspect, dark stance, and details
- add unit tests for NLU mappings

## Testing
- `npm test` *(fails: browserType.launch: Executable doesn't exist at /root/.cache/ms-playwright/...)*
- `npx vitest tests/lib/intake/nlu.test.ts`

------
https://chatgpt.com/codex/tasks/task_e_689d13662ae08322ae7172744ee1a2f7