### PR TITLE
Hook processing page to palette reveal

### DIFF
--- a/app/(shell)/start/processing/page.tsx
+++ b/app/(shell)/start/processing/page.tsx
@@ -2,16 +2,21 @@
 import { useEffect } from 'react'
 import { useRouter } from 'next/navigation'
 import { createPaletteFromInterview } from '@/lib/palette'
+import { moss } from '@/lib/ai/phrasing'
 
 export default function ProcessingPage() {
   const router = useRouter()
 
   useEffect(() => {
-    (async () => {
-      await createPaletteFromInterview()
-      router.replace('/reveal/test')
+    let active = true
+    ;(async () => {
+      const result = await createPaletteFromInterview()
+      if (active && result?.id) {
+        router.replace(`/reveal/${result.id}`)
+      }
     })()
+    return () => { active = false }
   }, [router])
 
-  return <div>Processing...</div>
+  return <div>{moss.working()}</div>
 }


### PR DESCRIPTION
## Summary
- call server to build palette from interview answers
- show moss working status and redirect to reveal page

## Testing
- `npx vitest run tests/ai/onboarding-api-flow.test.tsx` *(fails: React is not defined)*


------
https://chatgpt.com/codex/tasks/task_e_689d185966b88322bd73856d267f8309