### PR TITLE
Add tests for not-sure mapping and voice interview flow

### DIFF
--- a/tests/lib/intake/engine.test.ts
+++ b/tests/lib/intake/engine.test.ts
@@ -23,12 +23,14 @@ describe('buildQuestionQueue', () => {
 
 describe('capByPriority', () => {
   it('cap drop order unchanged', () => {
-    const q = ['style_primary','mood_words','dark_stance','dark_locations','room_type','light_level','window_aspect','K1','K1a','B1a','L1a','O2','constraints','avoid_colors','adjacent_primary_color','extra1','extra2']
+    const q = [
+      'style_primary','mood_words','dark_stance','dark_locations','room_type','light_level',
+      'window_aspect','K1','K1a','B1a','L1a','O2','constraints','avoid_colors','adjacent_primary_color','extra1','extra2'
+    ]
     capByPriority(q, {})
-    expect(q.length).toBe(15)
-    expect(q).not.toContain('K1a')
-    expect(q).not.toContain('B1a')
-    expect(q).toContain('dark_locations')
-    expect(q).toContain('window_aspect')
+    expect(q).toEqual([
+      'style_primary','mood_words','dark_stance','dark_locations','room_type','light_level',
+      'window_aspect','K1','L1a','O2','constraints','avoid_colors','adjacent_primary_color','extra1','extra2'
+    ])
   })
 })

--- a/tests/lib/intake/nlu.test.ts
+++ b/tests/lib/intake/nlu.test.ts
@@ -31,5 +31,7 @@ describe('nluParse', () => {
     expect(nluParse('window_aspect', 'not sure')).toBe('unknown')
     expect(nluParse('dark_stance', 'not sure')).toBe('open')
     expect(nluParse('fixed_details', 'not sure')).toBe('unsure')
+    expect(nluParse('style_primary', 'not sure')).toBe('mix')
+    expect(nluParse('dark_locations', 'not sure')).toEqual(['designer_suggest'])
   })
 })

--- a/tests/ui/voice-interview.test.tsx
+++ b/tests/ui/voice-interview.test.tsx
@@ -1,0 +1,65 @@
+import React from 'react'
+import { describe, it, expect, vi } from 'vitest'
+// Ensure React is available globally for components compiled with classic JSX runtime
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+(globalThis as any).React = React
+import { render, screen, fireEvent, waitFor } from '@testing-library/react'
+import VoiceInterview from '@/components/voice/VoiceInterview'
+
+const replace = vi.fn()
+vi.mock('next/navigation', () => ({
+  useRouter: () => ({ replace })
+}))
+vi.mock('@/lib/analytics', () => ({ track: vi.fn() }))
+vi.mock('@/lib/voice/session', () => ({
+  listenOnce: vi.fn(),
+  speak: vi.fn(),
+  startVoiceSession: vi.fn(),
+  stopSpeak: vi.fn(),
+}))
+import { listenOnce } from '@/lib/voice/session'
+
+const responses = [
+  'modern',
+  'calm cozy',
+  'open',
+  'trim',
+  'none',
+  'kitchen',
+  'bright',
+  'white cabinets'
+]
+const total = responses.length
+listenOnce.mockImplementation(() => Promise.resolve(responses.shift()!))
+
+describe('VoiceInterview', () => {
+  it('progresses through questions and completes', async () => {
+    render(<VoiceInterview />)
+
+    const questions = [
+      'How would you describe your style?',
+      'Give up to three mood words.',
+      'How do you feel about dark colors?',
+      'Where could we use dark colors?',
+      'Any constraints or rules we should know about?',
+      'Which room are we working on?',
+      'How is the light in this room?',
+      'Tell me about your kitchen details.'
+    ]
+
+    const mic = await screen.findByRole('button', { name: /tap to answer/i })
+
+    for (let i = 0; i < total; i++) {
+      expect(screen.getByText(questions[i])).toBeTruthy()
+      fireEvent.click(mic)
+      if (i < questions.length - 1) {
+        await screen.findByText(questions[i + 1])
+      }
+    }
+
+    await waitFor(() => {
+      expect(replace).toHaveBeenCalledWith('/start/processing')
+    })
+    expect(listenOnce).toHaveBeenCalledTimes(total)
+  })
+})


### PR DESCRIPTION
## Summary
- ensure capByPriority preserves original question order when capping
- expand nluParse "not sure" default coverage for style and dark locations
- simulate happy-path voice interview with mocked audio input

## Testing
- `npx vitest run tests/lib/intake/engine.test.ts tests/lib/intake/nlu.test.ts tests/ui/voice-interview.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_689d1a597b348322b86ecb4c33802fa1