### PR TITLE
chore(models): centralize model config, split realtime intake to mini, keep palette on gpt-4o

### DIFF
--- a/README.md
+++ b/README.md
@@ -348,7 +348,9 @@ Run Lighthouse in Chrome DevTools → check PWA + performance.
 
 ### AI configuration
 - `AI_ENABLE=true|false` — master switch for LLM calls (defaults to deterministic if false or key missing)
-- `AI_MODEL` — OpenAI model id (default `gpt-4o-mini`)
+- `OPENAI_MODEL` — model for palette/narrative generation (default `gpt-4o`)
+- `OPENAI_REALTIME_MODEL` — model for realtime intake and TTS (default `gpt-4o-mini` / `gpt-4o-mini-tts`)
+- `OPENAI_VISION_MODEL` — model for vision analysis (default `gpt-4o`)
 - `AI_MAX_OUTPUT_TOKENS` — cap response tokens (default 300)
 - `OPENAI_API_KEY` — required for any LLM usage (set in Vercel)
 - Status: visit `/api/ai/status` to verify `{ enabled, provider, model, hasKey }`

--- a/app/api/ai/preferences/route.ts
+++ b/app/api/ai/preferences/route.ts
@@ -4,6 +4,7 @@ import { designers } from "@/lib/ai/designers"
 import { startState, acceptAnswer, getCurrentNode, type InterviewState } from "@/lib/ai/onboardingGraph"
 import { buildStartUtterance, buildNextUtterance, ackFor, askFor } from "@/lib/ai/phrasing"
 import crypto from 'crypto'
+import { REALTIME_MODEL } from "@/lib/ai/config"
 
 const designerPrompts: Record<string,string> = {
   minimalist: 'You are a minimalist interior paint guide. Concise, calm, no fluff.',
@@ -64,7 +65,7 @@ async function phrase(systemPrompt: string, base: string, useLLM: boolean): Prom
     if(!OpenAI) throw new Error('NO_MOD')
     const client = new OpenAI({ apiKey: process.env.OPENAI_API_KEY })
     const resp = await client.chat.completions.create({
-      model: 'gpt-4o-mini',
+      model: REALTIME_MODEL,
       temperature: 0.3,
       max_tokens: 80,
       messages: [

--- a/app/api/realtime/offer/route.ts
+++ b/app/api/realtime/offer/route.ts
@@ -1,4 +1,5 @@
 export const runtime = 'nodejs'
+import { REALTIME_MODEL } from '@/lib/ai/config'
 
 export async function POST(req: Request) {
   // Use the EPHEMERAL client secret from the browser, not the long-lived server key.
@@ -11,8 +12,7 @@ export async function POST(req: Request) {
   const sdp = await req.text().catch(() => '')
   if (!sdp) return new Response('Empty SDP', { status: 400 })
 
-  const model = process.env.OPENAI_REALTIME_MODEL || 'gpt-4o-realtime-preview-2024-12-17'
-  const url = `https://api.openai.com/v1/realtime?model=${encodeURIComponent(model)}`
+  const url = `https://api.openai.com/v1/realtime?model=${encodeURIComponent(REALTIME_MODEL)}`
   try {
     const upstream = await fetch(url, {
       method: 'POST',

--- a/app/api/vision/analyze/route.ts
+++ b/app/api/vision/analyze/route.ts
@@ -1,5 +1,6 @@
 import OpenAI from "openai";
 import { NextRequest } from "next/server";
+import { VISION_MODEL } from "@/lib/ai/config";
 
 export async function POST(req: NextRequest) {
   try {
@@ -10,7 +11,7 @@ export async function POST(req: NextRequest) {
     if (!apiKey) return new Response(JSON.stringify({ error: "missing OpenAI API key" }), { status: 500 });
     const client = new OpenAI({ apiKey });
     const res = await client.responses.create({
-      model: process.env.OPENAI_MODEL || "gpt-4o-mini",
+      model: VISION_MODEL,
       input: [
         { role: "user", content: [
           { type: "input_text", text: "Report neutral observations useful for paint selection: undertones, relative contrast, and risks of color cast. Do NOT suggest specific paint colors." },

--- a/lib/ai/config.ts
+++ b/lib/ai/config.ts
@@ -1,4 +1,15 @@
+export const REALTIME_MODEL =
+  process.env.OPENAI_REALTIME_MODEL || 'gpt-4o-mini'
+
+export const REALTIME_TTS_MODEL =
+  process.env.OPENAI_REALTIME_MODEL || 'gpt-4o-mini-tts'
+
+export const AI_MODEL =
+  process.env.OPENAI_MODEL || 'gpt-4o'
+
+export const VISION_MODEL =
+  process.env.OPENAI_VISION_MODEL || 'gpt-4o'
+
 export const AI_ENABLE = process.env.AI_ENABLE === 'true'
-export const AI_MODEL = process.env.AI_MODEL || 'gpt-4o-mini'
 export const AI_MAX_OUTPUT_TOKENS = Number(process.env.AI_MAX_OUTPUT_TOKENS || 300)
 export const HAS_OPENAI_KEY = !!process.env.OPENAI_API_KEY

--- a/lib/voice/session.ts
+++ b/lib/voice/session.ts
@@ -1,4 +1,5 @@
 import { isVoiceEnabled } from '@/lib/flags'
+import { REALTIME_TTS_MODEL } from '@/lib/ai/config'
 
 let sessionId: string | null = null
 let audioCtx: AudioContext | null = null
@@ -27,7 +28,7 @@ export async function speak(text?: string, opts: { ssml?: string } = {}) {
         Authorization: `Bearer ${process.env.NEXT_PUBLIC_OPENAI_API_KEY}`,
       },
       body: JSON.stringify({
-        model: 'gpt-4o-mini-tts',
+        model: REALTIME_TTS_MODEL,
         input: opts.ssml ?? text,
         voice: process.env.NEXT_PUBLIC_TTS_VOICE || 'alloy',
         ...(sessionId ? { session_id: sessionId } : {}),


### PR DESCRIPTION
## Summary
- centralize GPT model IDs in a single `lib/ai/config.ts`
- run live intake and TTS on GPT-4o mini, keep palette and vision on GPT-4o
- update imports and docs to use new model constants

## Testing
- `npm run build` *(fails: compiled with warnings)*

------
https://chatgpt.com/codex/tasks/task_e_689d5e33a35c8322b3b9f3b99b538964