### PR TITLE
feat: implement conditional intake questionnaire

### DIFF
--- a/components/voice/VoiceInterview.tsx
+++ b/components/voice/VoiceInterview.tsx
@@ -7,6 +7,7 @@ import { IntakeTurnZ } from '@/lib/model-schema'
 import type { Answers } from '@/lib/intake/types'
 import { track } from '@/lib/analytics'
 import { getSection } from '@/lib/intake/sections'
+import { QUESTION_PRIORITY, QuestionId } from '@/lib/intake/questions'
 import { isVoiceEnabled } from '@/lib/flags'
 import VoiceStatusBar from '@/components/voice/VoiceStatusBar'
 
@@ -159,7 +160,8 @@ export default function VoiceInterview() {
             currentIdRef.current = turn.field_id
             setCurrentQuestion(turn.next_question)
             setActiveSection(getSection(turn.field_id))
-            track?.('question_shown', { id: turn.field_id, priority: 'P1' })
+            const pr = QUESTION_PRIORITY[turn.field_id as QuestionId] || 'P4'
+            track?.('question_shown', { id: turn.field_id, priority: pr })
           } catch (err) {
             console.error('parse', err)
             setStatus('error')
@@ -177,7 +179,8 @@ export default function VoiceInterview() {
               ...answersRef.current,
               [currentIdRef.current]: t,
             }
-            track?.('answer_saved', { id: currentIdRef.current, priority: 'P1' })
+            const pr = QUESTION_PRIORITY[currentIdRef.current as QuestionId] || 'P4'
+            track?.('answer_saved', { id: currentIdRef.current, priority: pr })
           } else if (msg.item?.role === 'assistant' && currentQuestion === '') {
             router.replace('/start/processing')
           }

--- a/lib/intake/engine.ts
+++ b/lib/intake/engine.ts
@@ -1,96 +1,104 @@
-import { Answers } from './types';
-import { getSection } from './sections';
+import { Answers } from './types'
+import { getSection } from './sections'
+import { QuestionId, QUESTION_PRIORITY } from './questions'
+import { track } from '@/lib/analytics'
 
-function pushIfUnanswered(q: string[], a: Answers, id: string) {
-  if (a[id] === undefined) q.push(id);
-}
-
-function needs(a: Answers, id: string): boolean {
+function isAnswered(a: Answers, id: QuestionId): boolean {
   switch (id) {
-    case 'dark_locations':
-      return a.dark_locations === undefined && ['walls', 'accents', 'open'].includes(a.dark_stance);
+    case 'theme':
+      return a.theme !== undefined || a.keepers !== undefined
+    case 'fixed_details':
+      return a.fixed_details !== undefined
     default:
-      return false;
+      return a[id] !== undefined
   }
 }
 
-function appendRoomModule(q: string[], a: Answers) {
-  switch (a.room_type) {
-    case 'kitchen':
-      pushIfUnanswered(q, a, 'K1');
-      if (Array.isArray(a.K1) && a.K1.length >= 2) pushIfUnanswered(q, a, 'K1a');
-      break;
-    case 'bathroom':
-      pushIfUnanswered(q, a, 'B1');
-      if (Array.isArray(a.B1) && a.B1.length >= 2) pushIfUnanswered(q, a, 'B1a');
-      break;
-    case 'living':
-    case 'dining':
-    case 'bedroom':
-    case 'office':
-      pushIfUnanswered(q, a, 'L1');
-      if (Array.isArray(a.L1) && a.L1.length >= 2) pushIfUnanswered(q, a, 'L1a');
-      break;
-    case 'nursery':
-    case 'kid':
-      pushIfUnanswered(q, a, 'N1');
-      break;
-    case 'hallway':
-    case 'entry':
-      pushIfUnanswered(q, a, 'H1');
-      if (a.adjacent_primary_color === undefined) q.push('adjacent_primary_color');
-      break;
-    case 'open':
-      pushIfUnanswered(q, a, 'O1');
-      if (a.O2 === undefined) q.push('O2');
-      break;
-    default:
-      break;
-  }
+function pushIfUnanswered(q: QuestionId[], a: Answers, id: QuestionId) {
+  if (!isAnswered(a, id)) q.push(id)
 }
 
-function hasColorRules(a: Answers): boolean {
-  return Array.isArray(a.constraints) && a.constraints.includes('color_rules');
-}
-
-export function capByPriority(q: string[], a: Answers) {
-  const MAX = 15;
-  const DROP_ORDER = ['K1a', 'B1a', 'L1a', 'O2', 'dark_locations', 'window_aspect', 'adjacent_primary_color'];
-  if (q.length <= MAX) return;
+export function capByPriority(q: QuestionId[], a: Answers) {
+  const MAX = 15
+  const DROP_ORDER: QuestionId[] = [
+    'fixed_details',
+    'coordination_preference',
+    'dark_locations',
+    'window_aspect',
+    'adjacent_primary_color',
+  ]
+  if (q.length <= MAX) return
   for (const id of DROP_ORDER) {
-    const idx = q.indexOf(id);
-    if (idx !== -1) {
-      q.splice(idx, 1);
-      if (q.length <= MAX) return;
+    const idx = q.indexOf(id)
+    if (idx !== -1 && q.length > MAX) {
+      q.splice(idx, 1)
+      const priority = QUESTION_PRIORITY[id]
+      track?.('question_dropped', { id, priority, reason: 'cap' })
+      track?.('flow_capped', { id, priority, reason: 'cap' })
     }
   }
-  while (q.length > MAX) q.pop();
+  while (q.length > MAX) {
+    const id = q.pop() as QuestionId
+    const priority = QUESTION_PRIORITY[id]
+    track?.('question_dropped', { id, priority, reason: 'cap' })
+    track?.('flow_capped', { id, priority, reason: 'cap' })
+  }
 }
 
-export function buildQuestionQueue(a: Answers): string[] {
-  const q: string[] = [];
+export function buildQuestionQueue(a: Answers): QuestionId[] {
+  const q: QuestionId[] = []
 
-  // PHASE A: STYLE
-  pushIfUnanswered(q, a, 'style_primary');
-  pushIfUnanswered(q, a, 'mood_words');
-  pushIfUnanswered(q, a, 'dark_stance');
-  if (needs(a, 'dark_locations')) q.push('dark_locations');
+  // Base P1
+  pushIfUnanswered(q, a, 'room_type')
+  pushIfUnanswered(q, a, 'mood_words')
+  pushIfUnanswered(q, a, 'style_primary')
+  pushIfUnanswered(q, a, 'light_level')
+  if (a.light_level === 'varies') pushIfUnanswered(q, a, 'window_aspect')
+  pushIfUnanswered(q, a, 'dark_stance')
 
-  // PHASE B: ROOM DETAILS
-  pushIfUnanswered(q, a, 'room_type');
-  pushIfUnanswered(q, a, 'light_level');
-  if (a.light_level === 'varies') q.push('window_aspect');
-
-  appendRoomModule(q, a);
-
-  pushIfUnanswered(q, a, 'constraints');
-  if (hasColorRules(a)) q.push('avoid_colors');
-
-  capByPriority(q, a);
-  const style: string[] = [];
-  const room: string[] = [];
-  for (const id of q) {
-    (getSection(id) === 'style' ? style : room).push(id);
+  // Room modules
+  switch (a.room_type) {
+    case 'kitchen':
+    case 'bathroom':
+    case 'living_room':
+    case 'bedroom_adult':
+    case 'dining':
+    case 'home_office':
+    case 'open_concept':
+      pushIfUnanswered(q, a, 'fixed_elements')
+      if (Array.isArray(a.fixed_elements) && a.fixed_elements.length >= 2)
+        pushIfUnanswered(q, a, 'fixed_details')
+      break
+    case 'bedroom_kid':
+    case 'nursery':
+      pushIfUnanswered(q, a, 'theme')
+      break
+    case 'hallway_entry':
+      pushIfUnanswered(q, a, 'flow_targets')
+      if (Array.isArray(a.flow_targets) && a.flow_targets.length >= 1)
+        pushIfUnanswered(q, a, 'adjacent_primary_color')
+      break
   }
-  return [...style, ...room];
+
+  if (a.room_type === 'open_concept') {
+    pushIfUnanswered(q, a, 'anchors_keep')
+    pushIfUnanswered(q, a, 'coordination_preference')
+  }
+
+  // Constraints
+  pushIfUnanswered(q, a, 'constraints')
+  if (Array.isArray(a.constraints) && a.constraints.includes('color_rules'))
+    pushIfUnanswered(q, a, 'avoid_colors')
+
+  if (a.dark_stance && a.dark_stance !== 'avoid')
+    pushIfUnanswered(q, a, 'dark_locations')
+
+  capByPriority(q, a)
+
+  const style: QuestionId[] = []
+  const room: QuestionId[] = []
+  for (const id of q) {
+    ;(getSection(id) === 'style' ? style : room).push(id)
+  }
+  return [...style, ...room]
 }

--- a/lib/intake/questions.ts
+++ b/lib/intake/questions.ts
@@ -1,0 +1,22 @@
+export type Priority = 'P1' | 'P2' | 'P3' | 'P4'
+
+export const QUESTION_PRIORITY = {
+  room_type: 'P1',
+  mood_words: 'P1',
+  style_primary: 'P1',
+  light_level: 'P1',
+  window_aspect: 'P3',
+  dark_stance: 'P1',
+  dark_locations: 'P3',
+  fixed_elements: 'P1',
+  fixed_details: 'P4',
+  anchors_keep: 'P1',
+  flow_targets: 'P1',
+  adjacent_primary_color: 'P3',
+  theme: 'P1',
+  constraints: 'P2',
+  avoid_colors: 'P3',
+  coordination_preference: 'P4',
+} as const
+
+export type QuestionId = keyof typeof QUESTION_PRIORITY

--- a/lib/intake/sections.ts
+++ b/lib/intake/sections.ts
@@ -1,18 +1,24 @@
 export type Section = 'style' | 'room'
 
 export const QUESTION_SECTIONS: Record<string, Section> = {
-  style_primary: 'style',
-  mood_words: 'style',
-  dark_stance: 'style',
-  dark_locations: 'style',
   room_type: 'room',
+  mood_words: 'style',
+  style_primary: 'style',
   light_level: 'room',
   window_aspect: 'room',
-};
+  dark_stance: 'style',
+  dark_locations: 'style',
+  fixed_elements: 'room',
+  fixed_details: 'room',
+  anchors_keep: 'room',
+  flow_targets: 'room',
+  adjacent_primary_color: 'room',
+  theme: 'room',
+  constraints: 'room',
+  avoid_colors: 'room',
+  coordination_preference: 'room',
+}
 
-// Helper for ids not explicitly listed: modules like K*, B*, L*, N*, H*, O*, C* are all room
 export function getSection(id: string): Section {
-  return (
-    QUESTION_SECTIONS[id] || (/^[KBLNHOC]/.test(id) ? 'room' : 'style')
-  );
+  return QUESTION_SECTIONS[id] || 'room'
 }

--- a/lib/intake/types.ts
+++ b/lib/intake/types.ts
@@ -1,1 +1,41 @@
-export type Answers = Record<string, any>;
+export type RoomType =
+  | 'living_room' | 'kitchen' | 'bedroom_adult' | 'bedroom_kid' | 'nursery'
+  | 'bathroom' | 'dining' | 'home_office' | 'hallway_entry' | 'open_concept'
+
+export type LightLevel = 'bright' | 'moderate' | 'low' | 'varies'
+export type WindowAspect = 'north' | 'south' | 'east' | 'west' | 'multiple' | 'unknown'
+export type DarkStance = 'walls' | 'accents' | 'avoid' | 'open'
+
+export type ConstraintKey =
+  | 'kids_pets' | 'renting' | 'hoa' | 'low_voc' | 'color_rules' | 'budget'
+export type DarkLocation =
+  | 'all_walls' | 'accent_wall' | 'ceiling' | 'trim_doors' | 'cabinetry' | 'designer_suggest'
+
+export type FixedElement =
+  | 'ctops' | 'backsplash' | 'cabinets' | 'flooring' | 'appliances'
+  | 'vanity_top' | 'tile' | 'fixtures_finish' | 'bath_flooring'
+  | 'wood_floor' | 'fireplace' | 'builtins_trim' | 'major_furniture' | 'rugs_textiles' | 'artwork'
+
+export type AnchorOpenConcept = 'dark_floor' | 'stone' | 'metal' | 'large_sofa_rug' | 'none'
+
+export interface Answers {
+  room_type?: RoomType
+  mood_words?: string[]
+  style_primary?: string
+  light_level?: LightLevel
+  window_aspect?: WindowAspect
+  dark_stance?: DarkStance
+  dark_locations?: DarkLocation[]
+  fixed_elements?: FixedElement[]
+  fixed_details?: Record<string, string>
+  anchors_keep?: AnchorOpenConcept[]
+  flow_targets?: string[]
+  adjacent_primary_color?: string
+  theme?: string
+  keepers?: string[]
+  constraints?: ConstraintKey[]
+  avoid_colors?: string[]
+  uploads?: string[]
+  coordination_preference?: string
+  [key: string]: any
+}

--- a/tests/lib/intake/engine.test.ts
+++ b/tests/lib/intake/engine.test.ts
@@ -1,36 +1,70 @@
 import { buildQuestionQueue, capByPriority } from '@/lib/intake/engine'
-import { getSection } from '@/lib/intake/sections'
+import type { QuestionId } from '@/lib/intake/questions'
 
 describe('buildQuestionQueue', () => {
-  it('reordered queue groups style before room', () => {
-    const q = buildQuestionQueue({
-      dark_stance: 'walls',
-      light_level: 'varies',
-      room_type: 'kitchen',
-      constraints: ['color_rules'],
-    })
-    const firstRoom = q.findIndex(id => getSection(id) === 'room')
-    expect(firstRoom).toBeGreaterThan(-1)
-    expect(q.slice(0, firstRoom).every(id => getSection(id) === 'style')).toBe(true)
-    expect(q.slice(firstRoom).every(id => getSection(id) === 'room')).toBe(true)
+  it('nursery path asks theme', () => {
+    const q = buildQuestionQueue({ room_type: 'nursery' })
+    expect(q).toContain('theme')
+    expect(q).not.toContain('fixed_elements')
   })
 
-  it('includes dark_locations when stance triggers', () => {
-    const q = buildQuestionQueue({ dark_stance: 'walls' })
-    expect(q[2]).toBe('dark_locations')
+  it('kitchen path includes fixed elements', () => {
+    const q = buildQuestionQueue({ room_type: 'kitchen' })
+    expect(q).toContain('fixed_elements')
+    expect(q).not.toContain('theme')
+  })
+
+  it('hallway follow-up added when targets selected', () => {
+    const q = buildQuestionQueue({ room_type: 'hallway_entry', flow_targets: ['kitchen'] })
+    expect(q).toContain('adjacent_primary_color')
+  })
+
+  it('open concept includes anchors and coordination', () => {
+    const q = buildQuestionQueue({ room_type: 'open_concept' })
+    expect(q).toContain('anchors_keep')
+    expect(q).toContain('coordination_preference')
   })
 })
 
 describe('capByPriority', () => {
-  it('cap drop order unchanged', () => {
+  it('drops in priority order', () => {
     const q = [
-      'style_primary','mood_words','dark_stance','dark_locations','room_type','light_level',
-      'window_aspect','K1','K1a','B1a','L1a','O2','constraints','avoid_colors','adjacent_primary_color','extra1','extra2'
-    ]
-    capByPriority(q, {})
+      'room_type',
+      'mood_words',
+      'style_primary',
+      'light_level',
+      'window_aspect',
+      'dark_stance',
+      'fixed_elements',
+      'fixed_details',
+      'anchors_keep',
+      'coordination_preference',
+      'constraints',
+      'avoid_colors',
+      'dark_locations',
+      'adjacent_primary_color',
+      'extra1',
+      'extra2',
+      'extra3',
+      'extra4',
+    ] as QuestionId[]
+    capByPriority(q, {} as any)
     expect(q).toEqual([
-      'style_primary','mood_words','dark_stance','dark_locations','room_type','light_level',
-      'window_aspect','K1','L1a','O2','constraints','avoid_colors','adjacent_primary_color','extra1','extra2'
+      'room_type',
+      'mood_words',
+      'style_primary',
+      'light_level',
+      'window_aspect',
+      'dark_stance',
+      'fixed_elements',
+      'anchors_keep',
+      'constraints',
+      'avoid_colors',
+      'adjacent_primary_color',
+      'extra1',
+      'extra2',
+      'extra3',
+      'extra4',
     ])
   })
 })


### PR DESCRIPTION
## Summary
- add question priority map and detailed intake types
- build deterministic question queue with cap and instrumentation
- wire voice interview analytics to question priorities
- add unit tests for engine paths and cap behavior

## Testing
- `npx vitest run --include tests/lib/intake/engine.test.ts` *(fails: Playwright tests executed)*
- `npx tsx -e "import {buildQuestionQueue} from './lib/intake/engine'; console.log('nursery', buildQuestionQueue({room_type:'nursery'})); console.log('kitchen', buildQuestionQueue({room_type:'kitchen', light_level:'varies', fixed_elements:['ctops','cabinets']})); console.log('hallway', buildQuestionQueue({room_type:'hallway_entry', flow_targets:['kitchen']})); console.log('open', buildQuestionQueue({room_type:'open_concept', light_level:'varies', dark_stance:'walls', fixed_elements:['wood_floor','fireplace'], constraints:['color_rules']}));"`

------
https://chatgpt.com/codex/tasks/task_e_689d6b7c27888322a705d0c8cf554248