### PR TITLE
Switch voice interview to intake engine queue

### DIFF
--- a/app/api/ai/preferences/route.ts
+++ b/app/api/ai/preferences/route.ts
@@ -1,80 +1,46 @@
 export const runtime = "nodejs"
+
 import { NextResponse } from "next/server"
-import { designers } from "@/lib/ai/designers"
-import { startState, acceptAnswer, getCurrentNode, type InterviewState } from "@/lib/ai/onboardingGraph"
-import { buildStartUtterance, buildNextUtterance, ackFor, askFor } from "@/lib/ai/phrasing"
-import crypto from 'crypto'
-import { REALTIME_MODEL } from "@/lib/ai/config"
+import { buildQuestionQueue } from "@/lib/intake/engine"
+import type { Answers } from "@/lib/intake/types"
+import type { IntakeTurnT } from "@/lib/model-schema"
+import type { QuestionId } from "@/lib/intake/questions"
 
-const designerPrompts: Record<string,string> = {
-  minimalist: 'You are a minimalist interior paint guide. Concise, calm, no fluff.',
-  playful: 'You are an upbeat playful design buddy. Encouraging, vivid but brief.',
-  pro: 'You are a seasoned interior designer. Professional, decisive, warm.'
+const PROMPTS: Record<QuestionId, { text: string; input_type: IntakeTurnT['input_type']; choices?: string[] | null }> = {
+  room_type: { text: "Which room are you working on?", input_type: "text" },
+  mood_words: { text: "Give a couple vibe words you like.", input_type: "text" },
+  style_primary: { text: "How would you describe your style?", input_type: "text" },
+  light_level: { text: "How much natural light does the room get?", input_type: "text" },
+  window_aspect: { text: "Which direction do the windows face?", input_type: "text" },
+  dark_stance: { text: "How do you feel about dark paint?", input_type: "text" },
+  dark_locations: { text: "Where would you use dark paint?", input_type: "text" },
+  fixed_elements: { text: "Any fixed elements to consider?", input_type: "text" },
+  fixed_details: { text: "Any details about those elements?", input_type: "text" },
+  anchors_keep: { text: "Which anchors will remain in the space?", input_type: "text" },
+  flow_targets: { text: "Which nearby rooms should coordinate?", input_type: "text" },
+  adjacent_primary_color: { text: "What's the main color in the adjacent room?", input_type: "text" },
+  theme: { text: "Any theme or inspiration for the room?", input_type: "text" },
+  constraints: { text: "Any constraints we should know?", input_type: "text" },
+  avoid_colors: { text: "Any colors to avoid?", input_type: "text" },
+  coordination_preference: {
+    text: "How should colors coordinate across spaces?",
+    input_type: "text",
+  },
 }
-
-interface StartBody { designerId: string; step: 'start' }
-interface AnswerBody { designerId: string; step: 'answer'; content: string; state: InterviewState }
- type Body = StartBody | AnswerBody
 
 export async function POST(req: Request) {
-  const body = await req.json() as Body
-  const designer = designers.find(d => d.id === body.designerId)
-  if(!designer) return NextResponse.json({ error:'Unknown designer' },{ status:400 })
-  const systemPrompt = designerPrompts[designer.id] || 'You are a helpful concise design assistant.'
-  const useLLM = !!process.env.OPENAI_API_KEY
-  let state: InterviewState
-  let utterance = ''
-  if(body.step === 'start'){
-    state = startState()
-    state.rngSeed = state.rngSeed || crypto.randomUUID()
-    const q = getCurrentNode(state)
-    const base = buildStartUtterance(designer.id, state.rngSeed!, q.prompt)
-    utterance = await phrase(systemPrompt, base, useLLM)
-    return NextResponse.json({ state, utterance })
+  const body = (await req.json().catch(() => ({}))) as { answers?: Answers }
+  const answers: Answers = body.answers || {}
+  const queue = buildQuestionQueue(answers)
+  const nextId = queue[0]
+  if (!nextId) return NextResponse.json({ turn: null })
+  const info = PROMPTS[nextId]
+  const turn: IntakeTurnT = {
+    field_id: nextId,
+    next_question: info.text,
+    input_type: info.input_type,
+    choices: info.choices ?? null,
   }
-  state = acceptAnswer(body.state, body.content)
-  state.rngSeed = state.rngSeed || body.state.rngSeed || crypto.randomUUID()
-  if(state.done){
-    const closing = 'Perfect—that’s enough to design your palette.'
-    utterance = await phrase(systemPrompt, closing, useLLM)
-    return NextResponse.json({ state, utterance })
-  }
-  const prevKey = body.state.currentKey || getCurrentNode(body.state).key
-  const next = getCurrentNode(state)
-  const ack = ackFor(prevKey, body.content, state.rngSeed || 'x')
-  const ask = askFor(next, state.rngSeed || 'x')
-  const base = buildNextUtterance(ack, ask)
-  utterance = await phrase(systemPrompt, base, useLLM)
-  return NextResponse.json({ state, utterance })
+  return NextResponse.json({ turn })
 }
 
-function clampWords(s: string, maxWords = 28){
-  const w = s.split(/\s+/)
-  if(w.length <= maxWords) return s
-  return w.slice(0,maxWords).join(' ') + '…'
-}
-
-async function phrase(systemPrompt: string, base: string, useLLM: boolean): Promise<string>{
-  if(!useLLM) return clampWords(base)
-  try{
-    if(!process.env.OPENAI_API_KEY) throw new Error('NO_KEY')
-    const modName = 'openai'
-    // @ts-ignore
-    const dynamicMod = await (Function('m','return import(m)'))(modName).catch(()=>null)
-    const OpenAI = dynamicMod?.OpenAI
-    if(!OpenAI) throw new Error('NO_MOD')
-    const client = new OpenAI({ apiKey: process.env.OPENAI_API_KEY })
-    const resp = await client.chat.completions.create({
-      model: REALTIME_MODEL,
-      temperature: 0.3,
-      max_tokens: 80,
-      messages: [
-        { role:'system', content: systemPrompt + '\nConstraints: one short acknowledgment then one question; concise.' },
-        { role:'user', content: `Rewrite more naturally: "${base}"` }
-      ]
-    })
-    return clampWords(resp.choices[0]?.message?.content?.trim() || base)
-  } catch {
-    return clampWords(base)
-  }
-}

--- a/tests/lib/intake/engine.test.ts
+++ b/tests/lib/intake/engine.test.ts
@@ -24,6 +24,16 @@ describe('buildQuestionQueue', () => {
     expect(q).toContain('anchors_keep')
     expect(q).toContain('coordination_preference')
   })
+
+  it('asks dark locations when stance not avoid', () => {
+    const q = buildQuestionQueue({ dark_stance: 'walls' })
+    expect(q).toContain('dark_locations')
+  })
+
+  it('skips dark locations when stance avoid', () => {
+    const q = buildQuestionQueue({ dark_stance: 'avoid' })
+    expect(q).not.toContain('dark_locations')
+  })
 })
 
 describe('capByPriority', () => {


### PR DESCRIPTION
## Summary
- Serve next intake question from `buildQuestionQueue` in preferences API
- Voice interview now fetches server questions instead of model-driven BEGIN
- Test intake engine and voice interview branching on dark paint answers

## Testing
- `npx vitest run tests/lib/intake/engine.test.ts tests/ui/voice-interview.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_689d755b6dfc83229a9c7998696ee0eb