### PR TITLE
Enhance AI interview flow with persona tone and palette reveal step

### DIFF
--- a/app/(shell)/start/processing/page.tsx
+++ b/app/(shell)/start/processing/page.tsx
@@ -1,22 +1,41 @@
 "use client"
-import { useEffect } from 'react'
-import { useRouter } from 'next/navigation'
+import { useEffect, useState } from 'react'
+import { useRouter, useSearchParams } from 'next/navigation'
 import { createPaletteFromInterview } from '@/lib/palette'
 import { moss } from '@/lib/ai/phrasing'
 
 export default function ProcessingPage() {
   const router = useRouter()
+  const sp = useSearchParams()
+  const [storyId, setStoryId] = useState<string | null>(sp.get('id'))
 
   useEffect(() => {
     let active = true
-    ;(async () => {
-      const result = await createPaletteFromInterview()
-      if (active && result?.id) {
-        router.replace(`/reveal/${result.id}`)
-      }
-    })()
-    return () => { active = false }
-  }, [router])
+    if (!storyId) {
+      ;(async () => {
+        const result = await createPaletteFromInterview()
+        if (active && result?.id) {
+          setStoryId(result.id)
+        }
+      })()
+    }
+    return () => {
+      active = false
+    }
+  }, [storyId])
 
-  return <div>{moss.working()}</div>
+  return (
+    <div className="flex flex-col items-center gap-4 py-10">
+      <p>{storyId ? moss.complete() : moss.working()}</p>
+      {storyId && (
+        <button
+          type="button"
+          onClick={() => router.replace(`/reveal/${storyId}`)}
+          className="rounded-xl bg-black px-4 py-2 text-white"
+        >
+          Reveal My Palette
+        </button>
+      )}
+    </div>
+  )
 }

--- a/app/api/ai/preferences/route.ts
+++ b/app/api/ai/preferences/route.ts
@@ -1,46 +1,191 @@
-export const runtime = "nodejs"
+export const runtime = 'nodejs'
 
-import { NextResponse } from "next/server"
-import { buildQuestionQueue } from "@/lib/intake/engine"
-import type { Answers } from "@/lib/intake/types"
-import type { IntakeTurnT } from "@/lib/model-schema"
-import type { QuestionId } from "@/lib/intake/questions"
+import { NextResponse } from 'next/server'
+import { buildQuestionQueue } from '@/lib/intake/engine'
+import type { Answers } from '@/lib/intake/types'
+import type { QuestionId } from '@/lib/intake/questions'
+import type { IntakeTurnT } from '@/lib/model-schema'
+import { ackFor } from '@/lib/ai/phrasing'
+import { nluParse } from '@/lib/intake/nlu'
 
-const PROMPTS: Record<QuestionId, { text: string; input_type: IntakeTurnT['input_type']; choices?: string[] | null }> = {
-  room_type: { text: "Which room are you working on?", input_type: "text" },
-  mood_words: { text: "Give a couple vibe words you like.", input_type: "text" },
-  style_primary: { text: "How would you describe your style?", input_type: "text" },
-  light_level: { text: "How much natural light does the room get?", input_type: "text" },
-  window_aspect: { text: "Which direction do the windows face?", input_type: "text" },
-  dark_stance: { text: "How do you feel about dark paint?", input_type: "text" },
-  dark_locations: { text: "Where would you use dark paint?", input_type: "text" },
-  fixed_elements: { text: "Any fixed elements to consider?", input_type: "text" },
-  fixed_details: { text: "Any details about those elements?", input_type: "text" },
-  anchors_keep: { text: "Which anchors will remain in the space?", input_type: "text" },
-  flow_targets: { text: "Which nearby rooms should coordinate?", input_type: "text" },
-  adjacent_primary_color: { text: "What's the main color in the adjacent room?", input_type: "text" },
-  theme: { text: "Any theme or inspiration for the room?", input_type: "text" },
-  constraints: { text: "Any constraints we should know?", input_type: "text" },
-  avoid_colors: { text: "Any colors to avoid?", input_type: "text" },
+const GREETINGS: Record<string, string> = {
+  therapist: "Hello! I’m Moss, your Color Therapist. Let’s get started.",
+  minimalist: "Hello! I’m Moss, your Minimalist guide. Let’s begin.",
+  naturalist: "Hello! I’m Moss, your Cozy Naturalist. Let’s get started.",
+}
+
+type Prompt = {
+  text: string
+  input_type: IntakeTurnT['input_type']
+  choices?: string[] | null
+  validation?: IntakeTurnT['validation']
+}
+
+const PROMPTS: Record<QuestionId, Prompt> = {
+  room_type: {
+    text: 'Which space are we designing? (e.g. Living Room, Kitchen, Bedroom…) ',
+    input_type: 'singleSelect',
+    choices: [
+      'Living Room',
+      'Kitchen',
+      'Bedroom',
+      "Kid's Room",
+      'Nursery',
+      'Dining Room',
+      'Home Office',
+      'Bathroom',
+      'Open Concept',
+      'Hallway/Entry',
+      'Other',
+    ],
+    validation: { required: true },
+  },
+  mood_words: {
+    text: 'In three words, how should this room feel?',
+    input_type: 'text',
+    validation: { required: true, max: 3 },
+  },
+  style_primary: {
+    text: 'Which style resonates most with you?',
+    input_type: 'singleSelect',
+    choices: [
+      'Modern Minimalist',
+      'Organic Cottage',
+      'Moody Traditional',
+      'Japandi',
+      'Scandinavian',
+      'Industrial',
+      'Bohemian',
+      'Coastal',
+      'Mid-Century',
+      'Transitional',
+      'Not sure',
+    ],
+    validation: { required: true },
+  },
+  light_level: {
+    text: 'How much natural light does the room get?',
+    input_type: 'singleSelect',
+    choices: ['Bright', 'Mixed', 'Low', 'Not sure'],
+    validation: { required: true },
+  },
+  window_aspect: {
+    text: 'Which direction do the windows face?',
+    input_type: 'singleSelect',
+    choices: ['North', 'East', 'South', 'West', 'Not sure'],
+  },
+  dark_stance: {
+    text: 'How do you feel about dark paint?',
+    input_type: 'singleSelect',
+    choices: [
+      'Avoid dark paint',
+      'Maybe an accent wall',
+      'Trim or accents only',
+      'Open to dark anywhere',
+      'Not sure',
+    ],
+    validation: { required: true },
+  },
+  dark_locations: {
+    text: 'Where would you use dark paint?',
+    input_type: 'multiSelect',
+    choices: ['Walls', 'Trim', 'Ceiling', 'Cabinetry', 'Doors', 'Island', 'Not sure'],
+  },
+  fixed_elements: {
+    text: 'Any fixed elements to consider in this room?',
+    input_type: 'multiSelect',
+    choices: [
+      'Flooring',
+      'Cabinetry',
+      'Counters',
+      'Backsplash',
+      'Fireplace',
+      'Ceiling beams',
+      'Built-ins',
+      'Furniture',
+      'Appliances',
+      'Not sure',
+    ],
+  },
+  fixed_details: {
+    text: 'Any details about those elements?',
+    input_type: 'text',
+  },
+  anchors_keep: {
+    text: 'Which anchors will remain in the space?',
+    input_type: 'text',
+  },
+  flow_targets: {
+    text: 'Which nearby rooms should coordinate?',
+    input_type: 'multiSelect',
+    choices: ['Kitchen', 'Dining', 'Living', 'Hallway', 'Bedroom', 'Bathroom', 'Other', 'Not sure'],
+  },
+  adjacent_primary_color: {
+    text: "What's the main color in the adjacent room?",
+    input_type: 'singleSelect',
+    choices: ['White/Neutral', 'Warm Neutrals', 'Cool Neutrals', 'Blue', 'Green', 'Red/Pink', 'Yellow', 'Other', 'Not sure'],
+  },
+  theme: { text: 'Any theme or inspiration for the room?', input_type: 'text' },
+  constraints: {
+    text: 'Any constraints we should know?',
+    input_type: 'multiSelect',
+    choices: ['Kids/Pets', 'Renting', 'Low VOC', 'HOA rules', 'Color rules', 'Other'],
+  },
+  avoid_colors: { text: 'Any colors to avoid?', input_type: 'text' },
   coordination_preference: {
-    text: "How should colors coordinate across spaces?",
-    input_type: "text",
+    text: 'How should colors coordinate across spaces?',
+    input_type: 'singleSelect',
+    choices: ['Shared palette throughout', 'Each room its own', 'Not sure'],
   },
 }
 
+function promptFor(id: QuestionId, answers: Answers): Prompt {
+  const base = PROMPTS[id]
+  if (id === 'fixed_elements') {
+    const room = (answers.room_type || 'room').replace(/_/g, ' ')
+    return { ...base, text: `Which ${room} elements need to coordinate with paint?` }
+  }
+  return base
+}
+
 export async function POST(req: Request) {
-  const body = (await req.json().catch(() => ({}))) as { answers?: Answers }
+  const body = (await req.json().catch(() => ({}))) as {
+    answers?: Answers
+    designerId?: string
+    last_question?: QuestionId
+    last_answer?: string
+  }
+  const designerId = body.designerId || 'therapist'
   const answers: Answers = body.answers || {}
+
+  if (body.last_question && body.last_answer !== undefined) {
+    answers[body.last_question] = nluParse(body.last_question, body.last_answer)
+  }
+
   const queue = buildQuestionQueue(answers)
   const nextId = queue[0]
+
   if (!nextId) return NextResponse.json({ turn: null })
-  const info = PROMPTS[nextId]
+
+  const info = promptFor(nextId, answers)
+  let questionText = info.text
+
+  if (!body.last_question) {
+    const greet = GREETINGS[designerId] || GREETINGS.therapist
+    questionText = `${greet} ${questionText}`
+  } else if (body.last_answer !== undefined) {
+    const ack = ackFor(body.last_question, body.last_answer, 'seed')
+    questionText = `${ack} ${questionText}`
+  }
+
   const turn: IntakeTurnT = {
     field_id: nextId,
-    next_question: info.text,
+    next_question: questionText,
     input_type: info.input_type,
     choices: info.choices ?? null,
+    validation: info.validation || null,
   }
+
   return NextResponse.json({ turn })
 }
 

--- a/components/ai/PreferencesChat.tsx
+++ b/components/ai/PreferencesChat.tsx
@@ -1,9 +1,10 @@
 "use client"
 import * as React from 'react'
+import Link from 'next/link'
 import { usePreferencesChat } from '@/lib/hooks/usePreferencesChat'
 
 export default function PreferencesChat({ designerId }: { designerId: string }) {
-  const { currentNode, utterance, input, setInput, busy, done, statusText, submit } =
+  const { currentQuestion, choices, input, setInput, busy, done, statusText, submit, storyId } =
     usePreferencesChat(designerId)
 
   return (
@@ -13,16 +14,16 @@ export default function PreferencesChat({ designerId }: { designerId: string }) 
       className="rounded-2xl border border-white/15 bg-white/5 p-4 text-white/95"
     >
       <div className="min-h-[120px]">
-        {utterance ? (
-          <p className="text-base md:text-lg">{utterance}</p>
+        {currentQuestion ? (
+          <p className="text-base md:text-lg">{currentQuestion}</p>
         ) : (
           <p className="opacity-80">Preparing questions…</p>
         )}
         {statusText && <p className="mt-2 text-sm opacity-80">{statusText}</p>}
       </div>
-      {Array.isArray(currentNode?.options) && currentNode.options.length > 0 && !done && (
+      {Array.isArray(choices) && choices.length > 0 && !done && (
         <div className="mt-3 flex flex-wrap gap-2">
-          {currentNode.options.map((o: string) => (
+          {choices.map((o: string) => (
             <button
               type="button"
               key={o}
@@ -55,6 +56,16 @@ export default function PreferencesChat({ designerId }: { designerId: string }) 
           >
             Send
           </button>
+        </div>
+      )}
+      {done && storyId && (
+        <div className="mt-4">
+          <Link
+            href={`/reveal/${storyId}`}
+            className="rounded-xl bg-white/20 px-4 py-2 text-sm hover:bg-white/25"
+          >
+            Reveal My Palette
+          </Link>
         </div>
       )}
     </div>

--- a/lib/ai/phrasing.ts
+++ b/lib/ai/phrasing.ts
@@ -65,6 +65,15 @@ export function ackFor(prevKey: string, userText: string, rngSeed: string) {
       const m = userText.toLowerCase().startsWith('sher')? 'Sherwin-Williams':'Behr'
       return pick(rng,[`${m}—solid choice.`,`${m} works great.`])
     }
+    case 'room_type': {
+      const clean = userText.trim()
+      const joins = [
+        `Great, a ${clean}—got it.`,
+        `${clean}? Love it.`,
+        `${clean}—sounds good.`,
+      ]
+      return pick(rng, joins)
+    }
     case 'avoid': return pick(rng,["Noted—avoiding it.","Got it—steering clear."])
     case 'fixed': return pick(rng,["Will match those.","Finishes noted."])
     case 'trim': return pick(rng,["Trim noted.","We’ll match trim."])

--- a/lib/intake/nlu.ts
+++ b/lib/intake/nlu.ts
@@ -59,6 +59,19 @@ const LOCATION_SYNONYMS: Record<string, string[]> = {
   island: ['island'],
 };
 
+const ROOM_SYNONYMS: Record<string, string[]> = {
+  kitchen: ['kitchen'],
+  bathroom: ['bathroom', 'bath', 'powder'],
+  living_room: ['living', 'living room', 'family room'],
+  bedroom_adult: ['bedroom', 'primary bedroom', 'master'],
+  bedroom_kid: ["kid's room", 'kids room', 'child room', 'teen room'],
+  nursery: ['nursery'],
+  dining: ['dining', 'dining room'],
+  home_office: ['home office', 'office', 'study'],
+  open_concept: ['open concept', 'open', 'great room'],
+  hallway_entry: ['hallway', 'entry', 'foyer'],
+};
+
 export function nluParse(id: string, transcript: string): any {
   const text = transcript.trim().toLowerCase();
 
@@ -98,6 +111,9 @@ export function nluParse(id: string, transcript: string): any {
         west: ['west', 'west-facing', 'west facing'],
       };
       return mapFromSynonyms(MAP, text) || 'unknown';
+    }
+    case 'room_type': {
+      return mapFromSynonyms(ROOM_SYNONYMS, text) || text.replace(/\s+/g, '_');
     }
     default:
       return text;


### PR DESCRIPTION
## Summary
- Add room-type NLU mapping and therapist-styled acknowledgements for personalized prompts
- Expand preference prompts with full questionnaire wording and choices, plus greeting/acknowledgment logic
- Generate palette behind the scenes in voice and chat interviews and expose a "Reveal My Palette" flow

## Testing
- `npm test` *(fails: Executable doesn't exist at /root/.cache/ms-playwright/...)*

------
https://chatgpt.com/codex/tasks/task_e_689df3d6fef88322b06257549810563c