### PR TITLE
fix: handle undefined question in ack

### DIFF
--- a/app/api/ai/preferences/route.ts
+++ b/app/api/ai/preferences/route.ts
@@ -183,7 +183,8 @@ export async function POST(req: Request) {
     const ack = ackFor(body.last_question, body.last_answer, designerId)
     questionText = `${ack} ${questionText}`
   } else if (body.last_answer !== undefined) {
-    const ack = ackFor(body.last_question, body.last_answer, 'seed')
+    // If we have an answer but no matching question ID, fall back to a generic ack.
+    const ack = ackFor(body.last_question ?? '', body.last_answer, 'seed')
     questionText = `${ack} ${questionText}`
   } else if (!body.last_question) {
     const greet = GREETINGS[designerId] || GREETINGS.therapist


### PR DESCRIPTION
## Summary
- avoid TypeScript compile error when last_question is undefined by defaulting to a generic ack string

## Testing
- `npm run build`
- `npm test` *(fails: connection refused for Playwright tests, requires running server)*

------
https://chatgpt.com/codex/tasks/task_e_689dfde106148322a02697b982d7b4ef