### PR TITLE
fix: prime realtime model with system prompt for voice interview

### DIFF
--- a/tests/ui/voice-interview.test.tsx
+++ b/tests/ui/voice-interview.test.tsx
@@ -10,6 +10,75 @@ vi.mock('next/navigation', () => ({ useRouter: () => ({ replace }) }))
 vi.mock('@/lib/analytics', () => ({ track: vi.fn() }))
 
 describe('VoiceInterview realtime', () => {
+  it('sends a system prompt to prime the realtime model', async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce({ ok: true, json: () => Promise.resolve({ client_secret: { value: 'tok' } }) })
+      .mockResolvedValueOnce({ ok: true, text: () => Promise.resolve('remote-sdp') })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: () =>
+          Promise.resolve({
+            turn: {
+              field_id: 'room_type',
+              next_question:
+                "Hello! I’m Moss, your Color Therapist. Let’s get started. Which space are we designing? (e.g. Living Room, Kitchen, Bedroom…)",
+              input_type: 'singleSelect',
+              choices: null,
+              validation: null,
+            },
+          }),
+      })
+    ;(globalThis as any).fetch = fetchMock
+
+    ;(navigator as any).mediaDevices = {
+      getUserMedia: vi.fn(() => Promise.resolve({ getTracks: () => [{ stop: vi.fn() }] })),
+    }
+
+    ;(HTMLMediaElement.prototype as any).play = vi.fn(() => Promise.resolve())
+
+    let sent: any[] = []
+    let dc: any
+    const pc = {
+      addTransceiver: vi.fn(),
+      addTrack: vi.fn(),
+      createDataChannel: vi.fn(() => {
+        dc = {
+          onopen: null as any,
+          onmessage: null as any,
+          send: vi.fn((payload: string) => sent.push(JSON.parse(payload))),
+          readyState: 'open',
+        }
+        return dc
+      }),
+      createOffer: vi.fn(() => Promise.resolve({ sdp: 'local', type: 'offer' })),
+      setLocalDescription: vi.fn(),
+      localDescription: { sdp: 'local' },
+      iceGatheringState: 'complete',
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+      setRemoteDescription: vi.fn(),
+      getSenders: () => [],
+      close: vi.fn(),
+      ontrack: null as any,
+    }
+    ;(globalThis as any).RTCPeerConnection = vi.fn(() => pc)
+
+    render(<VoiceInterview />)
+    fireEvent.click(screen.getByRole('button', { name: /enable voice/i }))
+    await waitFor(() => expect(dc.onopen).toBeTruthy())
+    dc.onopen?.()
+
+    // first send should be a conversation.item.create with a system role
+    const first = sent.find((m) => m?.type === 'conversation.item.create')
+    expect(first?.item?.role).toBe('system')
+    expect(JSON.stringify(first)).toMatch(/Moss, an AI color consultant/)
+
+    // and we should ask the first question as audio/text
+    await waitFor(() => expect(sent.find((m) => m?.type === 'response.create')).toBeTruthy())
+    const ask = sent.find((m) => m?.type === 'response.create')
+    expect(ask?.response?.instructions).toMatch(/Which space are we designing\?/i)
+  })
   it('asks follow-up based on previous answer', async () => {
     const fetchMock = vi
       .fn()


### PR DESCRIPTION
## Summary
- send Moss system prompt to realtime model before first turn and mirror greeting in deterministic fallback
- provide closing instructions instead of empty response to avoid stray adjectives
- test realtime flow primes system prompt and asks correct first question

## Testing
- `npm test` *(fails: browserType.launch: Executable doesn't exist at /root/.cache/ms-playwright/...)*
- `npx vitest tests/ui/voice-interview.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_689e070182fc8322a30410c9babd6eda