### PR TITLE
feat: add realtalk types and API helper

### DIFF
--- a/lib/realtalk/api.ts
+++ b/lib/realtalk/api.ts
@@ -1,0 +1,11 @@
+import { TurnRequest, TurnResponse } from './types';
+
+export async function postTurn(payload: TurnRequest): Promise<TurnResponse> {
+  const res = await fetch('/api/ai/preferences', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(payload),
+  });
+  if (!res.ok) throw new Error('Turn request failed');
+  return res.json();
+}

--- a/lib/realtalk/types.ts
+++ b/lib/realtalk/types.ts
@@ -1,0 +1,40 @@
+export type InputType = 'singleSelect' | 'multiSelect' | 'text';
+
+export type Validation = {
+  required?: boolean;
+  max?: number; // e.g., mood_words clamped to 3 words
+};
+
+export type PromptChoice = {
+  id: string;        // normalized value the backend expects
+  label: string;     // display label
+};
+
+export type PromptSpec = {
+  id: string;             // QuestionId (e.g., "room_type")
+  text: string;           // Display prompt
+  input_type: InputType;  // singleSelect | multiSelect | text
+  choices?: PromptChoice[];
+  validation?: Validation;
+  section?: 'style' | 'room'; // optional hint
+};
+
+export type Answers = Record<string, string | string[] | null>;
+
+export type TurnResponse = {
+  // next prompt to render; null means done
+  prompt: PromptSpec | null;
+  // server can echo normalized answers (after nluParse)
+  answers: Answers;
+  // friendly greeting/persona line when starting
+  greeting?: string;
+  // progress hint if backend wants to share it
+  progress?: { asked: number; maxCap?: number };
+};
+
+export type TurnRequest = {
+  answers: Answers;       // latest answers object
+  ack?: { id: string; value: string | string[] }; // what user just answered
+  mode?: 'next' | 'explain';
+  explainFor?: string; // questionId to explain (when mode==='explain')
+};


### PR DESCRIPTION
## Summary
- add shared types for RealTalk prompt turns
- provide API wrapper for submitting turns

## Testing
- `npm run lint`
- `npm run typecheck`
- `npm test` *(fails: missing Playwright dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_689e1478f344832294b814c9dea46f37