### PR TITLE
feat: add speech recognition hook

### DIFF
--- a/hooks/useSpeech.ts
+++ b/hooks/useSpeech.ts
@@ -1,0 +1,51 @@
+import { useEffect, useRef, useState, useCallback } from 'react';
+
+type UseSpeechOptions = {
+  lang?: string;
+  onFinal?: (text: string) => void;
+};
+
+export function useSpeech({ lang = 'en-US', onFinal }: UseSpeechOptions) {
+  const recRef = useRef<SpeechRecognition | null>(null);
+  const [supported, setSupported] = useState(false);
+  const [listening, setListening] = useState(false);
+  const [interim, setInterim] = useState('');
+
+  useEffect(() => {
+    const SR = (window as any).SpeechRecognition || (window as any).webkitSpeechRecognition;
+    if (SR) {
+      const rec = new SR();
+      rec.continuous = false;
+      rec.interimResults = true;
+      rec.lang = lang;
+      rec.onresult = (e: SpeechRecognitionEvent) => {
+        let finalText = '';
+        let interimText = '';
+        for (let i = e.resultIndex; i < e.results.length; i++) {
+          const t = e.results[i][0].transcript;
+          if (e.results[i].isFinal) finalText += t;
+          else interimText += t;
+        }
+        setInterim(interimText);
+        if (finalText && onFinal) onFinal(finalText.trim());
+      };
+      rec.onend = () => setListening(false);
+      recRef.current = rec as SpeechRecognition;
+      setSupported(true);
+    }
+  }, [lang, onFinal]);
+
+  const start = useCallback(() => {
+    if (!recRef.current) return;
+    setInterim('');
+    setListening(true);
+    recRef.current.start();
+  }, []);
+
+  const stop = useCallback(() => {
+    recRef.current?.stop();
+  }, []);
+
+  return { supported, listening, interim, start, stop };
+}
+


### PR DESCRIPTION
## Summary
- add `useSpeech` hook for speech recognition support

## Testing
- `npm run lint`
- `npm test` *(fails: browserType.launch: Executable doesn't exist at /root/.cache/ms-playwright/chromium_headless_shell-1181/chrome-linux/ headless_shell)*

------
https://chatgpt.com/codex/tasks/task_e_689e15cae30c8322b7be779c50677cfd