### PR TITLE
feat: add explain API route

### DIFF
--- a/app/api/ai/explain/route.ts
+++ b/app/api/ai/explain/route.ts
@@ -1,0 +1,39 @@
+export const runtime = 'nodejs'
+
+import { NextResponse } from 'next/server'
+
+export async function POST(req: Request) {
+  const { questionText, answers } = await req.json()
+
+  // Try OpenAI if KEY exists, else fall back to a rule-based explainer.
+  const key = process.env.OPENAI_API_KEY
+  const prompt = `Explain this interview question to a homeowner in 2-4 friendly sentences.
+Question: "${questionText}"
+Context (prior answers): ${JSON.stringify(answers ?? {}, null, 0)}
+Keep it non-technical and give a quick example if helpful.`
+
+  if (key) {
+    const r = await fetch('https://api.openai.com/v1/chat/completions', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${key}` },
+      body: JSON.stringify({
+        model: 'gpt-4o-mini',
+        messages: [
+          { role: 'system', content: 'You are a friendly interior design assistant.' },
+          { role: 'user', content: prompt }
+        ],
+        temperature: 0.3
+      })
+    })
+    if (!r.ok) return NextResponse.json({ explanation: defaultExplain(questionText) })
+    const data = await r.json()
+    const explanation = data?.choices?.[0]?.message?.content?.trim() || defaultExplain(questionText)
+    return NextResponse.json({ explanation })
+  }
+
+  return NextResponse.json({ explanation: defaultExplain(questionText) })
+}
+
+function defaultExplain(questionText: string) {
+  return `We ask “${questionText}” to better tailor recommendations. Answering in your own words is great; choose a suggested option if it fits.`
+}


### PR DESCRIPTION
## Summary
- add `/api/ai/explain` endpoint to generate friendly question explanations via OpenAI or fallback text

## Testing
- `npm run lint`
- `npm run typecheck` *(fails: hooks/useSpeech.ts cannot find types SpeechRecognition/SpeechRecognitionEvent)*
- `npm test` *(fails: Playwright browsers missing)*

------
https://chatgpt.com/codex/tasks/task_e_689e172cb37c8322bb13e8ecdc8a1e81