### PR TITLE
Add text interview page and mode switcher

### DIFF
--- a/app/(shell)/start/interview/page.tsx
+++ b/app/(shell)/start/interview/page.tsx
@@ -1,5 +1,23 @@
+import Link from 'next/link'
 import VoiceInterview from '@/components/voice/VoiceInterview'
 
-export default function InterviewPage() {
-  return <VoiceInterview />
+function ModeSwitcher() {
+  return (
+    <div style={{ margin: '12px 0 24px', fontSize: 14, opacity: 0.9 }}>
+      Prefer typing or tapping?{' '}
+      <Link href="/start/text-interview" style={{ textDecoration: 'underline' }}>
+        Try the text interview →
+      </Link>
+    </div>
+  )
 }
+
+export default function InterviewPage() {
+  return (
+    <>
+      <ModeSwitcher />
+      <VoiceInterview />
+    </>
+  )
+}
+

--- a/app/(shell)/start/text-interview/page.tsx
+++ b/app/(shell)/start/text-interview/page.tsx
@@ -1,0 +1,15 @@
+import RealTalkQuestionnaire from '@/components/realtalk/RealTalkQuestionnaire';
+
+export const metadata = {
+  title: 'RealTalk — Text Interview',
+  description: 'Answer by clicking, typing, or speaking. One question at a time.',
+};
+
+export default function Page() {
+  return (
+    <main style={{ padding: 24 }}>
+      <RealTalkQuestionnaire autoStart />
+    </main>
+  );
+}
+


### PR DESCRIPTION
## Summary
- Add dedicated text interview page that hosts the RealTalk questionnaire
- Add mode switcher on voice interview page linking to text interview

## Testing
- `npm test` *(fails: browserType.launch executable doesn't exist)*
- `npm run lint`
- `npm run typecheck` *(fails: SpeechRecognition types missing)*

------
https://chatgpt.com/codex/tasks/task_e_689e1a86e0908322a55f1f319411a83f