### PR TITLE
Define speech recognition types to fix build

### DIFF
--- a/hooks/useSpeech.ts
+++ b/hooks/useSpeech.ts
@@ -1,5 +1,23 @@
 import { useEffect, useRef, useState, useCallback } from 'react';
 
+interface SpeechRecognitionEvent {
+  resultIndex: number;
+  results: Array<{
+    0: { transcript: string };
+    isFinal: boolean;
+  }>;
+}
+
+interface SpeechRecognition {
+  continuous: boolean;
+  interimResults: boolean;
+  lang: string;
+  onresult: (event: SpeechRecognitionEvent) => void;
+  onend: () => void;
+  start: () => void;
+  stop: () => void;
+}
+
 type UseSpeechOptions = {
   lang?: string;
   onFinal?: (text: string) => void;


### PR DESCRIPTION
## Summary
- declare minimal `SpeechRecognition` and `SpeechRecognitionEvent` interfaces
- reference these types in `useSpeech` hook to compile against Web Speech API

## Testing
- `npm run typecheck`
- `npm run lint`
- `npm test` *(fails: page.goto net::ERR_CONNECTION_REFUSED at http://localhost:3000/preferences/therapist)*

------
https://chatgpt.com/codex/tasks/task_e_689e20032eb88322affbdb08ae82106e