### PR TITLE
Fix questionnaire advancing

### DIFF
--- a/components/realtalk/RealTalkQuestionnaire.tsx
+++ b/components/realtalk/RealTalkQuestionnaire.tsx
@@ -61,8 +61,9 @@ export default function RealTalkQuestionnaire({ initialAnswers = {}, autoStart =
 
   async function nextTurn(ack?: { id: string; value: string | string[] }) {
     setLoading(true);
+    const mergedAnswers = ack ? { ...answers, [ack.id]: ack.value } : answers;
     try {
-      const res: TurnResponse = await postTurn({ answers, ack, mode: 'next' });
+      const res: TurnResponse = await postTurn({ answers: mergedAnswers, ack, mode: 'next' });
       if (res.greeting) setGreeting(res.greeting);
       if (res.prompt) {
         setCurrent(res.prompt);
@@ -72,7 +73,11 @@ export default function RealTalkQuestionnaire({ initialAnswers = {}, autoStart =
       } else {
         setCurrent(null); // done!
       }
-      if (res.answers) setAnswers(res.answers);
+      if (res.answers) {
+        setAnswers(res.answers);
+      } else {
+        setAnswers(mergedAnswers);
+      }
       if (ack) setHistory((h) => [...h, ack]);
     } finally {
       setLoading(false);

--- a/lib/realtalk/api.ts
+++ b/lib/realtalk/api.ts
@@ -1,10 +1,16 @@
 import { TurnRequest, TurnResponse } from './types';
 
 export async function postTurn(payload: TurnRequest): Promise<TurnResponse> {
+  const { ack, ...rest } = payload;
+  const body: Record<string, any> = { ...rest };
+  if (ack) {
+    body.last_question = ack.id;
+    body.last_answer = Array.isArray(ack.value) ? ack.value.join(', ') : ack.value;
+  }
   const res = await fetch('/api/ai/preferences', {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify(payload),
+    body: JSON.stringify(body),
   });
   if (!res.ok) throw new Error('Turn request failed');
   return res.json();


### PR DESCRIPTION
## Summary
- ensure RealTalk questionnaire posts merged answers and track last question/answer
- include latest answer in API request to advance prompts properly

## Testing
- `npm test` *(fails: Target page, context or browser has been closed)*
- `npm run lint`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_689e2353219c832297ffe31636f9d3cc