### PR TITLE
fix metadata export error in text interview page

### DIFF
--- a/app/(shell)/start/text-interview/page.tsx
+++ b/app/(shell)/start/text-interview/page.tsx
@@ -1,5 +1,3 @@
-"use client"
-
 import RealTalkQuestionnaire from '@/components/realtalk/RealTalkQuestionnaire'
 
 export const metadata = {
@@ -9,16 +7,8 @@ export const metadata = {
 
 export default function Page() {
   return (
-    <main className="rt-container theme-moss">
+    <main className="grid items-start justify-center min-h-[calc(100dvh-16px)] p-[var(--space-10)] theme-moss">
       <RealTalkQuestionnaire autoStart />
-      <style jsx>{`
-        .rt-container {
-          display: grid;
-          place-items: start center;
-          min-height: calc(100dvh - 16px);
-          padding: var(--space-10);
-        }
-      `}</style>
     </main>
   )
 }


### PR DESCRIPTION
## Summary
- replace client page metadata export with server-compatible variant
- streamline text interview page styles with Tailwind classes

## Testing
- `npm test` *(fails: net::ERR_CONNECTION_REFUSED)*
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689e2d69811c8322a5cd46f490d39eca