### PR TITLE
feat: auto redirect from processing to reveal

### DIFF
--- a/app/(shell)/start/processing/page.tsx
+++ b/app/(shell)/start/processing/page.tsx
@@ -24,6 +24,13 @@ export default function ProcessingPage() {
     }
   }, [storyId])
 
+  // Automatically redirect to the reveal page once a story has been created
+  useEffect(() => {
+    if (storyId) {
+      router.replace(`/reveal/${storyId}`)
+    }
+  }, [storyId, router])
+
   return (
     <div className="flex flex-col items-center gap-4 py-10">
       <p>{storyId ? moss.complete() : moss.working()}</p>


### PR DESCRIPTION
## Summary
- auto-redirect from start/processing to palette reveal once the palette is ready
- keep a manual "Reveal My Palette" button as a fallback

## Testing
- `npm test`
- `npm run lint`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_689e33bdf6988322a2c8d36e389fc9bb