### PR TITLE
chore(routing): smart redirect /start/processing -> /reveal/:id?optimistic=1 or /start/interview

### DIFF
--- a/middleware.ts
+++ b/middleware.ts
@@ -4,7 +4,14 @@ import type { NextRequest } from 'next/server'
 export function middleware(req: NextRequest) {
   if (req.nextUrl.pathname === '/start/processing') {
     const url = req.nextUrl.clone()
-    url.pathname = '/start/interview'
+    const id = url.searchParams.get('id')
+    if (id) {
+      url.pathname = `/reveal/${id}`
+      url.searchParams.set('optimistic', '1')
+    } else {
+      url.pathname = '/start/interview'
+      url.search = '' // clear any old params
+    }
     return NextResponse.redirect(url, 308)
   }
   return NextResponse.next()


### PR DESCRIPTION
## Summary
- redirect /start/processing to /reveal/:id?optimistic=1 when id query present
- fallback to /start/interview without params

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689e5526c7088322a8f39fc9f9efd053