### PR TITLE
fix(supabase): re-export supabaseServer wrapper for back-compat

### DIFF
--- a/app/api/stories/[id]/download-zip/route.ts
+++ b/app/api/stories/[id]/download-zip/route.ts
@@ -1,9 +1,9 @@
 import { NextResponse } from "next/server";
 import JSZip from "jszip";
-import { createSupabaseServer } from "@/lib/supabase/server";
+import { supabaseServer } from "@/lib/supabase/server";
 
 export async function GET(_: Request, { params }: { params: { id: string } }) {
-  const supabase = createSupabaseServer();
+  const supabase = supabaseServer();
   const {
     data: { user },
   } = await supabase.auth.getUser();

--- a/app/api/stories/[id]/retry/route.ts
+++ b/app/api/stories/[id]/retry/route.ts
@@ -1,8 +1,8 @@
 import { NextResponse } from "next/server";
-import { createSupabaseServer } from "@/lib/supabase/server";
+import { supabaseServer } from "@/lib/supabase/server";
 
 export async function POST(_: Request, { params }: { params: { id: string } }) {
-  const supabase = createSupabaseServer();
+  const supabase = supabaseServer();
   const {
     data: { user },
   } = await supabase.auth.getUser();

--- a/app/api/stories/[id]/similar/route.ts
+++ b/app/api/stories/[id]/similar/route.ts
@@ -1,8 +1,8 @@
 import { NextResponse } from "next/server";
-import { createSupabaseServer } from "@/lib/supabase/server";
+import { supabaseServer } from "@/lib/supabase/server";
 
 export async function POST(req: Request, { params }: { params: { id: string } }) {
-  const supabase = createSupabaseServer();
+  const supabase = supabaseServer();
   const { data: { user } } = await supabase.auth.getUser();
   if (!user) return NextResponse.json({ error: "unauthorized" }, { status: 401 });
 

--- a/app/api/stories/[id]/status/route.ts
+++ b/app/api/stories/[id]/status/route.ts
@@ -1,8 +1,8 @@
 import { NextResponse } from "next/server";
-import { createSupabaseServer } from "@/lib/supabase/server";
+import { supabaseServer } from "@/lib/supabase/server";
 
 export async function GET(_: Request, { params }: { params: { id: string } }) {
-  const supabase = createSupabaseServer();
+  const supabase = supabaseServer();
   const { data: { user } } = await supabase.auth.getUser();
   if (!user) return NextResponse.json({ error: "unauthorized" }, { status: 401 });
 

--- a/app/api/story/route.ts
+++ b/app/api/story/route.ts
@@ -1,6 +1,6 @@
 import { NextResponse } from "next/server";
 import crypto from "node:crypto";
-import { createSupabaseServer } from "@/lib/supabase/server";
+import { supabaseServer } from "@/lib/supabase/server";
 
 function idemKey(payload: unknown) {
   return crypto
@@ -11,7 +11,7 @@ function idemKey(payload: unknown) {
 }
 
 export async function POST(req: Request) {
-  const supabase = createSupabaseServer();
+  const supabase = supabaseServer();
   const {
     data: { user },
   } = await supabase.auth.getUser();

--- a/lib/supabase/server.ts
+++ b/lib/supabase/server.ts
@@ -1,12 +1,49 @@
-import { cookies } from "next/headers";
-import { createServerClient } from "@supabase/ssr";
+import { cookies } from 'next/headers'
+import { createServerClient, type CookieOptions } from '@supabase/ssr'
 
-export function createSupabaseServer() {
+/**
+ * Server-side Supabase client for Next.js App Router.
+ * Provides new get/set/remove and legacy getAll/setAll cookie helpers.
+ */
+export function createSupabaseServerClient() {
+  const cookieStore = cookies()
+
   return createServerClient(
     process.env.NEXT_PUBLIC_SUPABASE_URL!,
     process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,
-    { cookies: cookies as any }
-  );
+    {
+      cookies: {
+        // New API
+        get(name: string) {
+          return cookieStore.get(name)?.value
+        },
+        set(name: string, value: string, options?: CookieOptions) {
+          try {
+            cookieStore.set({ name, value, ...options })
+          } catch {}
+        },
+        remove(name: string, options?: CookieOptions) {
+          try {
+            cookieStore.set({ name, value: '', ...options, maxAge: 0 })
+          } catch {}
+        },
+        // Legacy API still used by some @supabase/ssr internals
+        getAll() {
+          return cookieStore.getAll()
+        },
+        setAll(cookiesToSet: { name: string; value: string; options?: CookieOptions }[]) {
+          try {
+            cookiesToSet.forEach(({ name, value, options }) =>
+              cookieStore.set({ name, value, ...options })
+            )
+          } catch {}
+        },
+      } as any,
+    }
+  )
 }
 
-export const supabaseServer = createSupabaseServer;
+/** Back-compat name used across the app */
+export function supabaseServer() {
+  return createSupabaseServerClient()
+}


### PR DESCRIPTION
## Summary
- expose new `createSupabaseServerClient` with proper cookie helpers
- re-export `supabaseServer` wrapper and update API routes

## Testing
- `npm run build`
- `npm test` *(fails: browserType.launch: Executable doesn't exist at /root/.cache/ms-playwright/...)*

------
https://chatgpt.com/codex/tasks/task_e_689e5e466e2c83228dfcc3f5eb300932