### PR TITLE
fix(api): stop inserting non-existent stories.notes column

### DIFF
--- a/app/api/stories/route.ts
+++ b/app/api/stories/route.ts
@@ -113,7 +113,6 @@ export async function POST(req: Request) {
         vibe: body.vibe || null,
         palette: finalPalette,
         source: body.source || "interview",
-        notes: body.notes || null,
         status: "ready",                      // initial status; RevealPoller can read this
       })
       .select("id")


### PR DESCRIPTION
## Summary
- avoid inserting `stories.notes` column that doesn't exist

## Testing
- `npm run build`
- `npm test` *(fails: browserType.launch: Executable doesn't exist at /root/.cache/ms-playwright/chromium_headless_shell-1181/chrome-linux/headless_shell)*

------
https://chatgpt.com/codex/tasks/task_e_689e6c2cc68c8322bddbdaf0cdaedd8e