### PR TITLE
feat(nav): add mobile bottom navigation

### DIFF
--- a/app/favorites/page.tsx
+++ b/app/favorites/page.tsx
@@ -1,0 +1,5 @@
+import { redirect } from 'next/navigation';
+
+export default function FavoritesRedirect() {
+  redirect('/dashboard');
+}

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -20,6 +20,7 @@ import { getLocale, getMessages } from '@/lib/i18n'
 import { Inter, Fraunces } from 'next/font/google'
 const inter = Inter({ subsets: ['latin'], display: 'swap', variable: '--font-inter' })
 const fraunces = Fraunces({ subsets: ['latin'], display: 'swap', variable: '--font-fraunces' })
+import BottomNav from '@/components/nav/BottomNav'
 
 initSentry()
 
@@ -113,6 +114,9 @@ export default async function RootLayout({
                   <main id="main" className="min-h-dvh">
                     <AppShell><RouteTransition>{children}</RouteTransition></AppShell>
                   </main>
+                  {/* Spacer so content isn't obscured by the nav on mobile */}
+                  <div className="h-24 md:hidden" aria-hidden="true" />
+                  <BottomNav />
                 </AnalyticsProvider>
               </StartStoryPortalProvider>
               <SupabaseListener />

--- a/app/via/page.tsx
+++ b/app/via/page.tsx
@@ -1,0 +1,13 @@
+export default function ViaPage() {
+  return (
+    <main className="mx-auto max-w-md px-4 py-8">
+      <h1 className="text-2xl font-semibold tracking-tight">Via</h1>
+      <p className="mt-2 text-sm text-muted-foreground">
+        Ask our friendly design assistant anything about your space. (Full chat coming soon.)
+      </p>
+      <div className="mt-6 rounded-2xl border p-4">
+        <p className="text-sm">Try: “Softer trim with Shoji White walls?”</p>
+      </div>
+    </main>
+  );
+}

--- a/components/nav/BottomNav.tsx
+++ b/components/nav/BottomNav.tsx
@@ -1,38 +1,178 @@
-"use client"
-import React from 'react'
-import Link from 'next/link'
-import { usePathname } from 'next/navigation'
-import { Home, Heart, Grid3x3 } from 'lucide-react'
+'use client';
 
-const TABS = [
-  { href: '/home', label: 'Home', Icon: Home },
-  { href: '/stories', label: 'Stories', Icon: Heart },
-  { href: '/more', label: 'More', Icon: Grid3x3 }
-] as const
+import React from 'react';
+import Link from 'next/link';
+import { usePathname } from 'next/navigation';
+import { motion, useReducedMotion } from 'framer-motion';
+import {
+  Home as HomeIcon,
+  Sparkles,
+  Heart,
+  Ellipsis,
+  User,
+  CreditCard,
+  LifeBuoy,
+  HelpCircle,
+  Scale,
+  MessageSquare,
+  type LucideIcon,
+} from 'lucide-react';
+import { Sheet, SheetContent, SheetHeader, SheetTitle, SheetTrigger } from '@/components/ui/sheet';
 
-export function BottomNav(){
-  const pathname = usePathname() || '/'
-  return (
-    <nav aria-label="Primary" className="fixed inset-x-0 bottom-0 z-40 bg-[var(--color-bg)] backdrop-blur">
-      <div className="mx-auto max-w-3xl">
-        <ul className="grid grid-cols-3 gap-1 px-2 py-2 pb-[calc(0.5rem+env(safe-area-inset-bottom))]">
-          {TABS.map(({ href, label, Icon }) => {
-            const active = pathname === href || (href !== '/home' && pathname.startsWith(href))
-            return (
-              <li key={href} className="flex justify-center">
-                <div className={["w-full max-w-[160px] rounded-2xl px-2 py-1.5 text-center", active? 'bg-white/10':'hover:bg-white/5'].join(' ')}>
-                  <Link href={href} aria-current={active? 'page': undefined} className="flex flex-col items-center gap-0.5">
-                    <Icon className="h-5 w-5" />
-                    <span className="text-[11px] leading-none">{label}</span>
-                  </Link>
-                </div>
-              </li>
-            )
-          })}
-        </ul>
-      </div>
-    </nav>
-  )
+type Classy = (string | false | null | undefined)[];
+function cx(...c: Classy) {
+  return c.filter(Boolean).join(' ');
 }
 
-export default BottomNav
+type Item = {
+  href?: string;
+  label: 'Home' | 'Via' | 'Favorites' | 'More';
+  icon: LucideIcon;
+  onClick?: () => void;
+};
+
+export default function BottomNav() {
+  const pathname = usePathname();
+  const reduceMotion = useReducedMotion();
+
+  const isActive = (target: string | undefined) => {
+    if (!target) return false;
+    if (target === '/start') return pathname === '/' || pathname?.startsWith('/start');
+    if (target === '/dashboard') return pathname?.startsWith('/dashboard') || pathname?.startsWith('/reveal');
+    if (target === '/via') return pathname?.startsWith('/via');
+    return pathname === target;
+  };
+
+  const items: Item[] = [
+    { href: '/start', label: 'Home', icon: HomeIcon },
+    { href: '/via', label: 'Via', icon: Sparkles },
+    { href: '/dashboard', label: 'Favorites', icon: Heart },
+    // "More" handled via Sheet below
+    { label: 'More', icon: Ellipsis },
+  ];
+
+  return (
+    <nav className="fixed inset-x-0 bottom-0 z-50 md:hidden">
+      <div className="mx-auto max-w-md px-3 pb-[env(safe-area-inset-bottom)]">
+        <div className="rounded-2xl border bg-background/80 shadow-lg backdrop-blur supports-[backdrop-filter]:bg-background/60">
+          <ul className="grid grid-cols-4">
+            {items.slice(0, 3).map((item) => {
+              const ActiveIcon = item.icon;
+              const active = isActive(item.href);
+              return (
+                <li key={item.label}>
+                  <Link
+                    href={item.href!}
+                    aria-label={item.label}
+                    aria-current={active ? 'page' : undefined}
+                    className={cx(
+                      'group relative flex flex-col items-center gap-1 py-3 outline-none',
+                      'focus-visible:ring-2 focus-visible:ring-primary/40 focus-visible:ring-offset-2 focus-visible:ring-offset-background',
+                    )}
+                  >
+                    <motion.span
+                      className={cx('rounded-xl px-3 py-1')}
+                      whileTap={reduceMotion ? undefined : { scale: 0.94 }}
+                      transition={{ type: 'spring', stiffness: 400, damping: 30 }}
+                    >
+                      <ActiveIcon
+                        aria-hidden="true"
+                        className={cx(
+                          'h-6 w-6',
+                          active ? 'text-primary' : 'text-muted-foreground group-hover:text-foreground',
+                        )}
+                      />
+                    </motion.span>
+                    <span
+                      className={cx(
+                        'text-[11px] leading-none',
+                        active ? 'text-primary' : 'text-muted-foreground group-hover:text-foreground',
+                      )}
+                    >
+                      {item.label}
+                    </span>
+                  </Link>
+                </li>
+              );
+            })}
+
+            {/* More (Sheet) */}
+            <li>
+              <Sheet>
+                <SheetTrigger asChild>
+                  <button
+                    type="button"
+                    aria-label="More"
+                    className={cx(
+                      'group relative flex w-full flex-col items-center gap-1 py-3 outline-none',
+                      'focus-visible:ring-2 focus-visible:ring-primary/40 focus-visible:ring-offset-2 focus-visible:ring-offset-background',
+                    )}
+                  >
+                    <motion.span
+                      className="rounded-xl px-3 py-1"
+                      whileTap={reduceMotion ? undefined : { scale: 0.94 }}
+                      transition={{ type: 'spring', stiffness: 400, damping: 30 }}
+                    >
+                      <Ellipsis aria-hidden="true" className="h-6 w-6 text-muted-foreground group-hover:text-foreground" />
+                    </motion.span>
+                    <span className="text-[11px] leading-none text-muted-foreground group-hover:text-foreground">
+                      More
+                    </span>
+                    <span className="sr-only">Open account & help menu</span>
+                  </button>
+                </SheetTrigger>
+
+                <SheetContent
+                  side="bottom"
+                  className="rounded-t-2xl border-t bg-background/95 pb-[calc(env(safe-area-inset-bottom)+1rem)]"
+                >
+                  <SheetHeader>
+                    <SheetTitle className="text-base">More</SheetTitle>
+                  </SheetHeader>
+
+                  <div className="mt-4 grid grid-cols-2 gap-2">
+                    <MoreLink href="/account" icon={User} label="Profile" />
+                    <MoreLink href="/billing" icon={CreditCard} label="Billing" />
+                    <MoreLink href="/support" icon={LifeBuoy} label="Support" />
+                    <MoreLink href="/faq" icon={HelpCircle} label="FAQ" />
+                    <MoreLink href="/legal" icon={Scale} label="Legal" />
+                    <MoreLink href="/feedback" icon={MessageSquare} label="Feedback" />
+                  </div>
+
+                  <div className="mt-4 text-center text-xs text-muted-foreground">
+                    Bossy-but-kind guidance. Paint this weekend. :)
+                  </div>
+                </SheetContent>
+              </Sheet>
+            </li>
+          </ul>
+        </div>
+      </div>
+    </nav>
+  );
+}
+
+function MoreLink({
+  href,
+  label,
+  icon: Icon,
+}: {
+  href: string;
+  label: string;
+  icon: LucideIcon;
+}) {
+  return (
+    <Link
+      href={href}
+      className={cx(
+        'flex items-center gap-2 rounded-xl border p-3 text-sm transition',
+        'hover:bg-accent hover:text-accent-foreground',
+        'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/40',
+      )}
+    >
+      <Icon className="h-4 w-4" aria-hidden="true" />
+      <span>{label}</span>
+    </Link>
+  );
+}
+

--- a/components/ui/sheet.tsx
+++ b/components/ui/sheet.tsx
@@ -1,0 +1,62 @@
+'use client';
+
+import * as React from 'react';
+import * as DialogPrimitive from '@radix-ui/react-dialog';
+import { cn } from '@/lib/utils';
+
+const Sheet = DialogPrimitive.Root;
+const SheetTrigger = DialogPrimitive.Trigger;
+const SheetClose = DialogPrimitive.Close;
+
+interface SheetContentProps
+  extends React.ComponentPropsWithoutRef<typeof DialogPrimitive.Content> {
+  side?: 'top' | 'bottom' | 'left' | 'right';
+}
+
+const SheetContent = React.forwardRef<
+  React.ElementRef<typeof DialogPrimitive.Content>,
+  SheetContentProps
+>(({ side = 'right', className, children, ...props }, ref) => (
+  <DialogPrimitive.Portal>
+    <DialogPrimitive.Overlay className="fixed inset-0 z-50 bg-black/40 data-[state=open]:animate-in data-[state=closed]:animate-out" />
+    <DialogPrimitive.Content
+      ref={ref}
+      className={cn(
+        'fixed z-50 gap-4 bg-background p-6 shadow-lg border',
+        side === 'bottom' &&
+          'inset-x-0 bottom-0 rounded-t-2xl data-[state=open]:slide-in-from-bottom data-[state=closed]:slide-out-to-bottom',
+        side === 'top' &&
+          'inset-x-0 top-0 rounded-b-2xl data-[state=open]:slide-in-from-top data-[state=closed]:slide-out-to-top',
+        side === 'left' &&
+          'inset-y-0 left-0 h-full w-3/4 rounded-r-lg data-[state=open]:slide-in-from-left data-[state=closed]:slide-out-to-left',
+        side === 'right' &&
+          'inset-y-0 right-0 h-full w-3/4 rounded-l-lg data-[state=open]:slide-in-from-right data-[state=closed]:slide-out-to-right',
+        className,
+      )}
+      {...props}
+    >
+      {children}
+    </DialogPrimitive.Content>
+  </DialogPrimitive.Portal>
+));
+SheetContent.displayName = DialogPrimitive.Content.displayName;
+
+const SheetHeader = ({ className, ...props }: React.HTMLAttributes<HTMLDivElement>) => (
+  <div className={cn('flex flex-col space-y-2 text-center sm:text-left', className)} {...props} />
+);
+SheetHeader.displayName = 'SheetHeader';
+
+const SheetTitle = React.forwardRef<
+  React.ElementRef<typeof DialogPrimitive.Title>,
+  React.ComponentPropsWithoutRef<typeof DialogPrimitive.Title>
+>(({ className, ...props }, ref) => (
+  <DialogPrimitive.Title
+    ref={ref}
+    className={cn('text-lg font-semibold text-foreground', className)}
+    {...props}
+  />
+));
+SheetTitle.displayName = DialogPrimitive.Title.displayName;
+
+export { Sheet, SheetTrigger, SheetClose, SheetContent, SheetHeader, SheetTitle };
+

--- a/tests/components/BottomNav.test.tsx
+++ b/tests/components/BottomNav.test.tsx
@@ -1,0 +1,23 @@
+import { render, screen } from '@testing-library/react';
+import React from 'react';
+
+vi.mock('next/navigation', () => ({
+  usePathname: () => '/dashboard',
+}));
+
+import BottomNav from '@/components/nav/BottomNav';
+
+describe('BottomNav', () => {
+  it('renders 4 tabs with labels', () => {
+    render(<BottomNav />);
+    for (const label of ['Home', 'Via', 'Favorites', 'More']) {
+      expect(screen.getByLabelText(label)).toBeTruthy();
+    }
+  });
+
+  it('marks Favorites as current when on /dashboard', () => {
+    render(<BottomNav />);
+    const fav = screen.getByLabelText('Favorites');
+    expect(fav.getAttribute('aria-current')).toBe('page');
+  });
+});


### PR DESCRIPTION
## Summary
- add mobile bottom tab bar with Via, Favorites, and More sheet
- wire BottomNav into root layout and add Via and Favorites routes
- cover BottomNav with tests

## Testing
- `npx vitest tests/components/BottomNav.test.tsx`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689e8ac949d88322af3dd4b3e0121c98