### PR TITLE
feat: add unauthenticated account view and sign-in deep link

### DIFF
--- a/app/account/Unauthenticated.tsx
+++ b/app/account/Unauthenticated.tsx
@@ -1,0 +1,41 @@
+'use client';
+
+import Link from 'next/link';
+import { Button } from '@/components/ui';
+
+export default function UnauthenticatedAccount() {
+  return (
+    <main className="max-w-2xl mx-auto px-4 py-10">
+      <h1 className="font-display text-4xl leading-[1.05] mb-4">Account</h1>
+
+      <section className="rounded-2xl border border-linen bg-surface p-6 shadow-soft space-y-3">
+        <p className="text-sm text-muted-foreground">
+          You’re not signed in. Sign in to manage your profile, subscription, and saved Color Stories.
+        </p>
+
+        <div className="flex gap-2">
+          <Button
+            as={Link}
+            href="/sign-in?next=/account"
+            variant="outline"
+            aria-label="Sign in to your account"
+          >
+            Sign in
+          </Button>
+          <Button
+            as={Link}
+            href="/sign-in?next=/account&mode=password&pw=signup"
+            aria-label="Create a new account"
+          >
+            Create account
+          </Button>
+        </div>
+
+        <p className="text-xs text-muted-foreground">
+          One free story. Subscriptions for more. Bossy-but-kind guidance. 💛
+        </p>
+      </section>
+    </main>
+  );
+}
+

--- a/app/account/page.tsx
+++ b/app/account/page.tsx
@@ -13,7 +13,8 @@ export default async function AccountPage() {
   const supabase = supabaseServer()
   const { data: { user } } = await supabase.auth.getUser()
   if (!user) {
-    return <div className="p-8"><p>Please sign in to view your account.</p></div>
+    const { default: UnauthenticatedAccount } = await import('./Unauthenticated')
+    return <UnauthenticatedAccount />
   }
   const { tier } = await getUserTier()
 

--- a/app/sign-in/page.tsx
+++ b/app/sign-in/page.tsx
@@ -11,17 +11,19 @@ type Mode = 'magic' | 'password'
 type PwPhase = 'signin' | 'signup'
 
 export default function SignInPage() {
+  const searchParams = useSearchParams()
   const [email, setEmail] = useState('')
   const [password, setPassword] = useState('')
   const [confirm, setConfirm] = useState('')
-  const [mode, setMode] = useState<Mode>('magic')
-  const [pwPhase, setPwPhase] = useState<PwPhase>('signin')
+  const modeParam = searchParams.get('mode')
+  const pwParam = searchParams.get('pw')
+  const [mode, setMode] = useState<Mode>(() => (modeParam === 'password' ? 'password' : 'magic'))
+  const [pwPhase, setPwPhase] = useState<PwPhase>(() => (pwParam === 'signup' || pwParam === 'create' ? 'signup' : 'signin'))
   const [busy, setBusy] = useState(false)
   const [msg, setMsg] = useState<string | null>(null)
   const [awaitingConfirm, setAwaitingConfirm] = useState(false)
   const supabase = supabaseBrowser()
   const t = useTranslations('SignInPage')
-  const searchParams = useSearchParams()
   const next = searchParams.get('next') || '/dashboard'
 
   const origin =

--- a/tests/app/account/Unauthenticated.test.tsx
+++ b/tests/app/account/Unauthenticated.test.tsx
@@ -1,0 +1,13 @@
+import { render, screen } from '@testing-library/react';
+import React from 'react';
+import UnauthenticatedAccount from '@/app/account/Unauthenticated';
+
+describe('UnauthenticatedAccount', () => {
+  it('shows Sign in and Create account CTAs with correct links', () => {
+    render(<UnauthenticatedAccount />);
+    const signIn = screen.getByRole('link', { name: /sign in/i });
+    const create = screen.getByRole('link', { name: /create a new account/i });
+    expect(signIn).toHaveAttribute('href', '/sign-in?next=/account');
+    expect(create).toHaveAttribute('href', '/sign-in?next=/account&mode=password&pw=signup');
+  });
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -7,6 +7,9 @@ export default defineConfig({
       '@': path.resolve(__dirname, './'),
     }
   },
+  esbuild: {
+    jsx: 'automatic',
+  },
   test: {
     environment: 'jsdom',
     setupFiles: ['./tests/setup.ts'],


### PR DESCRIPTION
## Summary
- show sign-in and create-account CTAs for logged-out /account visitors
- deep-link sign-in page to password signup via query params
- support React automatic JSX runtime in vitest config

## Testing
- `npx vitest run tests/app/account/Unauthenticated.test.tsx`
- `npm run lint`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_689e8f12cb14832284e2b01066fcf552