### PR TITLE
Handle palette creation errors

### DIFF
--- a/components/realtalk/RealTalkQuestionnaire.tsx
+++ b/components/realtalk/RealTalkQuestionnaire.tsx
@@ -201,9 +201,13 @@ export default function RealTalkQuestionnaire({ initialAnswers = {}, autoStart =
                 // Prefer passing answers directly so we’re not relying on storage timing
                 setGenerationError(null)
                 const res = await createPaletteFromInterview(answers)
-                if ((res as any)?.error === 'AUTH_REQUIRED') {
+                if (res && 'error' in res) {
                   setGenerating(false)
-                  router.push('/sign-in?next=/start/interview')
+                  if (res.error === 'AUTH_REQUIRED') {
+                    router.push('/sign-in?next=/start/interview')
+                  } else {
+                    setGenerationError("Sorry — we couldn’t finish your Color Story. Please try again.")
+                  }
                   return
                 }
                 if (res?.id) {

--- a/lib/palette.ts
+++ b/lib/palette.ts
@@ -103,7 +103,7 @@ export function decodePalette(value: unknown): DecodedSwatch[] {
 }
 
 // Create a palette (story) from interview answers. Prefer explicit answers when provided.
-export async function createPaletteFromInterview(answersOverride?: any) {
+export async function createPaletteFromInterview(answersOverride?: any): Promise<{ id: string } | { error: 'AUTH_REQUIRED' | 'CREATE_FAILED' }> {
   // Skip network work in tests
   if (process.env.NODE_ENV === 'test') return { id: 'mock' };
 
@@ -153,11 +153,16 @@ export async function createPaletteFromInterview(answersOverride?: any) {
       if (typeof window !== 'undefined') {
         try { console.error('/api/stories failed', resp.status); } catch {}
       }
+      if (resp.status === 401 || data?.error === 'AUTH_REQUIRED') {
+        return { error: 'AUTH_REQUIRED' };
+      }
+      return { error: 'CREATE_FAILED' };
     }
   } catch (err) {
     if (typeof window !== 'undefined') {
       try { console.error('createPaletteFromInterview error', err); } catch {}
     }
+    return { error: 'CREATE_FAILED' };
   }
-  return null;
+  return { error: 'CREATE_FAILED' };
 }

--- a/tests/integration/createPaletteFromInterview.test.ts
+++ b/tests/integration/createPaletteFromInterview.test.ts
@@ -40,4 +40,30 @@ describe('createPaletteFromInterview', () => {
     expect(lsGet).toHaveBeenCalled()
     vi.unstubAllEnvs()
   })
+
+  it('returns AUTH_REQUIRED when API responds 401', async () => {
+    vi.stubEnv('NODE_ENV', 'development')
+    // @ts-ignore
+    global.fetch = vi.fn().mockResolvedValue({
+      ok: false,
+      status: 401,
+      json: async () => ({ error: 'AUTH_REQUIRED' })
+    })
+    const res = await mod.createPaletteFromInterview({ vibe: 'Custom' })
+    expect(res).toEqual({ error: 'AUTH_REQUIRED' })
+    vi.unstubAllEnvs()
+  })
+
+  it('returns CREATE_FAILED when API fails', async () => {
+    vi.stubEnv('NODE_ENV', 'development')
+    // @ts-ignore
+    global.fetch = vi.fn().mockResolvedValue({
+      ok: false,
+      status: 500,
+      json: async () => ({})
+    })
+    const res = await mod.createPaletteFromInterview({ vibe: 'Custom' })
+    expect(res).toEqual({ error: 'CREATE_FAILED' })
+    vi.unstubAllEnvs()
+  })
 })


### PR DESCRIPTION
## Summary
- return explicit error codes from `createPaletteFromInterview`
- handle palette creation errors in `RealTalkQuestionnaire`
- test palette creation error paths

## Testing
- `npm test` *(fails: browserType.launch: Executable doesn't exist at /root/.cache/ms-playwright/...)*
- `npx vitest run tests/integration/createPaletteFromInterview.test.ts`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689ea96cfb4083228214aa0b2072ff71