### PR TITLE
Map RealTalk answers to design inputs

### DIFF
--- a/app/api/via/answer/route.ts
+++ b/app/api/via/answer/route.ts
@@ -1,0 +1,31 @@
+export const runtime = 'nodejs'
+import OpenAI from 'openai'
+import { NextResponse } from 'next/server'
+
+const client = new OpenAI({ apiKey: process.env.OPENAI_API_KEY })
+
+export async function POST(req: Request) {
+  const { question, context } = await req.json().catch(() => ({}))
+  if (!question) return NextResponse.json({ error: 'MISSING_QUESTION' }, { status: 400 })
+
+  const schema = {
+    type: 'object',
+    properties: {
+      answer: { type: 'string' },
+      actions: { type: 'array', items: { type: 'string' } }, // e.g., ["suggest_trim", "check_contrast"]
+    },
+    required: ['answer'],
+    additionalProperties: false,
+  }
+
+  const resp = await client.responses.create({
+    model: 'gpt-5-mini',
+    input: [
+      { role: 'system', content: 'You are Via, an interior paint specialist. Be precise and actionable.' },
+      { role: 'user', content: JSON.stringify({ question, context }) },
+    ],
+    response_format: { type: 'json_schema', json_schema: { name: 'ViaAnswer', schema } } as any,
+  } as any)
+
+  return NextResponse.json(JSON.parse(resp.output_text || '{"answer":""}'))
+}

--- a/components/voice/VoiceInterview.tsx
+++ b/components/voice/VoiceInterview.tsx
@@ -187,7 +187,7 @@ export default function VoiceInterview() {
               const storyRes = await fetch('/api/stories', {
                 method: 'POST',
                 headers: { 'Content-Type': 'application/json' },
-                body: JSON.stringify({ designerKey: designerId, ...answersRef.current, seed: `voice:${Date.now()}` }),
+                body: JSON.stringify({ designerKey: designerId, answers: answersRef.current, seed: `voice:${Date.now()}` }),
               })
               const story = await storyRes.json().catch(() => null)
               const id = story?.id || story?.story?.id

--- a/lib/palette.ts
+++ b/lib/palette.ts
@@ -128,15 +128,13 @@ export async function createPaletteFromInterview(answersOverride?: any): Promise
       answers = stored;
     }
 
-    const { mapAnswersToStoryInput } = await import('@/lib/ai/onboardingGraph');
-    const payload = mapAnswersToStoryInput(answers || {});
-    // Ensure we send at least one meaningful field for validation
-    if (!payload.vibe) payload.vibe = 'Custom';
+    const { mapRealTalkToDesignInput } = await import('@/lib/realtalk/mapToDesignInput');
+    const payload = mapRealTalkToDesignInput(answers || {}); // brand, vibe, seed now always set
 
     const resp = await fetch('/api/stories', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ ...payload, source: 'interview' })
+      body: JSON.stringify({ ...payload, inputs: payload, answers, source: 'interview' })
     });
     const data = await resp.json().catch(() => null);
     if (resp.ok && data) {

--- a/lib/realtalk/mapToDesignInput.ts
+++ b/lib/realtalk/mapToDesignInput.ts
@@ -1,0 +1,56 @@
+import type { Answers } from '@/lib/intake/types'
+import type { DesignInput } from '@/lib/ai/schema'
+
+function brandFrom(a?: string): DesignInput['brand'] {
+  if (!a) return 'Sherwin-Williams'
+  return /behr/i.test(a) ? 'Behr' : 'Sherwin-Williams'
+}
+function lightingFrom(a?: string): DesignInput['lighting'] {
+  const t = String(a || '').toLowerCase()
+  if (t.includes('bright')) return 'Bright'
+  if (t.includes('low') || t.includes('dim') || t.includes('dark')) return 'Low'
+  return 'Mixed'
+}
+function contrastFrom(darkStance?: string): DesignInput['contrast'] {
+  const t = String(darkStance || '').toLowerCase()
+  if (t.includes('avoid')) return 'Softer'
+  if (t.includes('walls')) return 'Bolder'
+  // accents / open → balanced
+  return 'Balanced'
+}
+function vibeFrom(style?: string, moods?: string[] | string): string {
+  const s = (style || '').toString().replace(/_/g, ' ').trim()
+  const m = Array.isArray(moods) ? moods.slice(0, 2).join(' ') : String(moods || '')
+  const out = [s, m].filter(Boolean).join(' ').trim()
+  return out || 'Custom'
+}
+function fixedFrom(a: Answers): string | undefined {
+  const parts: string[] = []
+  if (Array.isArray(a.fixed_elements) && a.fixed_elements.length) parts.push(a.fixed_elements.join(', '))
+  if (a.fixed_details) parts.push(Object.values(a.fixed_details).join(', '))
+  const s = parts.filter(Boolean).join('; ')
+  return s ? s.slice(0, 300) : undefined
+}
+
+export function mapRealTalkToDesignInput(a: Answers): DesignInput {
+  const brand = brandFrom(a.brand as any)
+  const vibe = vibeFrom(a.style_primary as any, a.mood_words as any)
+  const seed = [
+    a.room_type || '',
+    a.style_primary || '',
+    Array.isArray(a.mood_words) ? a.mood_words.join('-') : a.mood_words || '',
+    brand,
+  ].join('|')
+
+  return {
+    space: (a.room_type || '').toString(),
+    lighting: lightingFrom(a.light_level as any),
+    vibe,
+    contrast: contrastFrom(a.dark_stance as any),
+    fixed: fixedFrom(a),
+    avoid: Array.isArray(a.avoid_colors) ? a.avoid_colors.join(', ') : (a.avoid_colors as any),
+    trim: undefined, // let orchestrator/defaults decide; wire later if you add a trim question
+    brand,
+    seed,
+  }
+}

--- a/tests/api/health-catalog.test.ts
+++ b/tests/api/health-catalog.test.ts
@@ -1,12 +1,11 @@
 import { describe, it, expect, vi } from 'vitest'
 
 vi.mock('@/lib/supabase/server', () => {
-  return {
-    supabaseServer: () => ({
-      auth: { getUser: async () => ({ data: { user: null } }) },
-      from: () => ({ select: async () => ({ count: 0 }) }),
-    }),
-  }
+  const client = () => ({
+    auth: { getUser: async () => ({ data: { user: null } }) },
+    from: () => ({ select: async () => ({ count: 0 }) }),
+  })
+  return { supabaseServer: client, createSupabaseServerClient: client }
 })
 
 import * as route from '@/app/api/health/catalog/route'

--- a/tests/api/stories-guest.test.ts
+++ b/tests/api/stories-guest.test.ts
@@ -2,12 +2,13 @@
 import { describe, it, expect, vi } from 'vitest'
 import * as storiesRoute from '@/app/api/stories/route'
 
-vi.mock('@/lib/supabase/server', () => ({
-  supabaseServer: () => ({
+vi.mock('@/lib/supabase/server', () => {
+  const client = () => ({
     auth: { getUser: async () => ({ data: { user: null }, error: null }) },
     from: () => ({ insert: () => ({ select: () => ({ single: async () => ({ data: null, error: null }) }) }) })
   })
-}))
+  return { supabaseServer: client, createSupabaseServerClient: client }
+})
 
 vi.mock('@/lib/ai/palette', () => ({
   seedPaletteFor: () => [{ brand: 'sherwin_williams', code: 'SW 7005', name: 'Pure White', hex: '#FEFEFE' }],

--- a/tests/api/stories-happy.test.ts
+++ b/tests/api/stories-happy.test.ts
@@ -2,8 +2,8 @@
 import { describe, it, expect, vi } from "vitest"
 import * as storiesRoute from "@/app/api/stories/route"
 
-vi.mock("@/lib/supabase/server", () => ({
-  supabaseServer: () => ({
+vi.mock("@/lib/supabase/server", () => {
+  const client = () => ({
     auth: { getUser: async () => ({ data: { user: { id: "u1" } }, error: null }) },
     from: () => ({
       insert: (_: any) => ({
@@ -12,8 +12,9 @@ vi.mock("@/lib/supabase/server", () => ({
         }),
       }),
     }),
-  }),
-}))
+  })
+  return { supabaseServer: client, createSupabaseServerClient: client }
+})
 
 vi.mock("@/lib/palette/normalize-repair", () => ({
   normalizePaletteOrRepair: async (p: any) => p,

--- a/tests/api/stories-legacy-compat.test.ts
+++ b/tests/api/stories-legacy-compat.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi } from 'vitest'
 
-vi.mock('@/lib/supabase/server', () => ({
-  supabaseServer: () => {
+vi.mock('@/lib/supabase/server', () => {
+  const client = () => {
     const swatches = [
       { brand:'sherwin_williams', code:'SW 7008', name:'Alabaster', hex:'#FFFFFF' },
       { brand:'sherwin_williams', code:'SW 7036', name:'Accessible Beige', hex:'#E5D8C8' },
@@ -17,7 +17,8 @@ vi.mock('@/lib/supabase/server', () => ({
       })
     }
   }
-}))
+  return { supabaseServer: client, createSupabaseServerClient: client }
+})
 
 const post = (json:any) => new Request('http://localhost/api/stories', { method:'POST', headers:{ 'Content-Type':'application/json' }, body: JSON.stringify(json) })
 

--- a/tests/api/stories-palette-v2.test.ts
+++ b/tests/api/stories-palette-v2.test.ts
@@ -2,8 +2,8 @@ import { describe, it, expect, vi } from 'vitest';
 // Use real Sherwin-Williams catalog data so validator passes.
 import sw from '@/data/brands/sw.json';
 
-vi.mock('@/lib/supabase/server', () => ({
-  supabaseServer: () => {
+vi.mock('@/lib/supabase/server', () => {
+  const client = () => {
     const swatches = [
       { brand:'sherwin_williams', code:'SW 7008', name:'Alabaster', hex:'#FFFFFF' },
       { brand:'sherwin_williams', code:'SW 7036', name:'Accessible Beige', hex:'#E5D8C8' },
@@ -19,7 +19,8 @@ vi.mock('@/lib/supabase/server', () => ({
       })
     }
   }
-}))
+  return { supabaseServer: client, createSupabaseServerClient: client }
+})
 
 vi.mock('@/lib/palette/normalize-repair', () => ({
   normalizePaletteOrRepair: async (p: any) => p,

--- a/tests/api/stories-validation.test.ts
+++ b/tests/api/stories-validation.test.ts
@@ -2,16 +2,17 @@
 import { describe, it, expect, vi } from 'vitest'
 import * as storiesRoute from '@/app/api/stories/route'
 
-vi.mock('@/lib/supabase/server', () => ({
-  supabaseServer: () => ({
+vi.mock('@/lib/supabase/server', () => {
+  const client = () => ({
     auth: { getUser: async () => ({ data: { user: { id: 'u1' } }, error: null }) },
     from: () => ({
       insert: () => ({ select: () => ({ single: async () => ({ data: { id: 's1' }, error: null }) }) }),
       update: () => ({ eq: async () => ({ error: null }) }),
       select: () => ({ eq: () => ({ single: async () => ({ data: { id: 's1', palette: [], vibe: 'Cozy Neutral' }, error: null }) }) }),
     }),
-  }),
-}))
+  })
+  return { supabaseServer: client, createSupabaseServerClient: client }
+})
 
 vi.mock('@/lib/ai/palette', () => ({
   seedPaletteFor: () => [{ brand: 'sherwin_williams', code: 'SW 7005', name: 'Pure White', hex: '#FEFEFE' }],

--- a/tests/api/variant-validation.test.ts
+++ b/tests/api/variant-validation.test.ts
@@ -2,8 +2,8 @@
 import { describe, it, expect, vi } from 'vitest'
 import * as variantRoute from '@/app/api/stories/[id]/variant/route'
 
-vi.mock('@/lib/supabase/server', () => ({
-  supabaseServer: () => ({
+vi.mock('@/lib/supabase/server', () => {
+  const client = () => ({
     auth: { getUser: async () => ({ data: { user: { id: 'u1' } }, error: null }) },
     from: () => ({
       select: () => ({
@@ -15,8 +15,9 @@ vi.mock('@/lib/supabase/server', () => ({
         }),
       }),
     }),
-  }),
-}))
+  })
+  return { supabaseServer: client, createSupabaseServerClient: client }
+})
 
 vi.mock('@/lib/ai/variants', () => ({
   makeVariant: (base: any) => base,

--- a/tests/repair-on-create.test.ts
+++ b/tests/repair-on-create.test.ts
@@ -3,8 +3,8 @@ import * as paletteModule from '@/lib/ai/palette'
 import * as orchestrator from '@/lib/ai/orchestrator'
 import { POST } from '@/app/api/stories/route'
 
-vi.mock('@/lib/supabase/server', () => ({
-  supabaseServer: () => {
+vi.mock('@/lib/supabase/server', () => {
+  const client = () => {
     const swatches = [
       { brand:'sherwin_williams', code:'SW 7008', name:'Alabaster', hex:'#FFFFFF' },
       { brand:'sherwin_williams', code:'SW 7036', name:'Accessible Beige', hex:'#E5D8C8' },
@@ -20,7 +20,8 @@ vi.mock('@/lib/supabase/server', () => ({
       })
     }
   }
-}))
+  return { supabaseServer: client, createSupabaseServerClient: client }
+})
 
 vi.mock('@/lib/palette/repair', () => ({ repairStoryPalette: async () => ({ ok:true }) }))
 vi.mock('@/lib/palette/normalize-repair', () => ({ normalizePaletteOrRepair: async () => [

--- a/tests/repair-on-reveal.test.ts
+++ b/tests/repair-on-reveal.test.ts
@@ -16,8 +16,8 @@ vi.mock('@/app/reveal/[id]/variant-tabs', () => ({ default: ()=> null }))
 vi.mock('@/app/reveal/[id]/reveal-client', () => ({ default: ()=> null }))
 vi.mock('@/lib/palette', () => ({ normalizePalette: () => { throw new Error('invalid') } }))
 
-vi.mock('@/lib/supabase/server', () => ({
-  supabaseServer: () => {
+vi.mock('@/lib/supabase/server', () => {
+  const client = () => {
     let first = true
     const repaired = [
       { brand:'sherwin_williams', code:'SW 7008', name:'Alabaster', hex:'#FFFFFF' },
@@ -36,7 +36,8 @@ vi.mock('@/lib/supabase/server', () => ({
       })
     }
   }
-}))
+  return { supabaseServer: client, createSupabaseServerClient: client }
+})
 
 vi.mock('@/lib/palette/normalize-repair', () => ({ normalizePaletteOrRepair: async () => [
   { brand:'sherwin_williams', code:'SW 7008', name:'Alabaster', hex:'#FFFFFF' },

--- a/tests/story-create-fallback.test.ts
+++ b/tests/story-create-fallback.test.ts
@@ -6,8 +6,8 @@ import * as orchestrator from '@/lib/ai/orchestrator'
 import { POST } from '@/app/api/stories/route'
 
 // Mock supabase server client used in route
-vi.mock('@/lib/supabase/server', () => ({
-  supabaseServer: () => {
+vi.mock('@/lib/supabase/server', () => {
+  const client = () => {
     const swatches = [
       { brand:'sherwin_williams', code:'SW 7008', name:'Alabaster', hex:'#FFFFFF' },
       { brand:'sherwin_williams', code:'SW 7036', name:'Accessible Beige', hex:'#E5D8C8' },
@@ -23,7 +23,8 @@ vi.mock('@/lib/supabase/server', () => ({
       })
     }
   }
-}))
+  return { supabaseServer: client, createSupabaseServerClient: client }
+})
 
 // Mock palette builder to return empty swatches triggering fallback
 vi.spyOn(orchestrator, 'designPalette').mockResolvedValue({


### PR DESCRIPTION
## Summary
- map RealTalk questionnaire answers to `DesignInput` including brand, vibe and seed
- use mapper in palette creation and voice interview
- derive story brand/vibe on server and add `/api/via/answer` endpoint

## Testing
- `npm test` *(fails: page.goto: net::ERR_CONNECTION_REFUSED at http://localhost:3000/reveal/tmp_test?optimistic=1)*
- `npm run lint`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_689eae1ec96883229d177485a8e36399