### PR TITLE
feat: add Via chat interface

### DIFF
--- a/app/via/page.tsx
+++ b/app/via/page.tsx
@@ -1,13 +1,148 @@
+'use client';
+
+import React, { useEffect, useState } from 'react';
+import './via.css';
+import AmbientEdge from '@/components/ui/ambient-edge';
+import PrefilledButtons from '@/components/via/PrefilledButtons';
+import ChatContainer, { ChatMessage } from '@/components/via/ChatContainer';
+import InputBar from '@/components/via/InputBar';
+import useSpeech from '@/hooks/useSpeech';
+import useFileUpload from '@/hooks/useFileUpload';
+import { cn } from '@/lib/utils';
+
 export default function ViaPage() {
+  const [messages, setMessages] = useState<ChatMessage[]>([]);
+  const [bootTyped, setBootTyped] = useState('');
+  const [showSuggestions, setShowSuggestions] = useState(true);
+
+  // Type-in intro "hi. i'm Via," once on mount
+  useEffect(() => {
+    const intro = "hi. i’m Via,";
+    let i = 0;
+    const id = setInterval(() => {
+      setBootTyped(intro.slice(0, ++i));
+      if (i === intro.length) clearInterval(id);
+    }, 35);
+    return () => clearInterval(id);
+  }, []);
+
+  const { isRecording, start, stop, transcript, supported: speechSupported } = useSpeech();
+
+  // When transcript updates (recording ended), push into input
+  const [pendingInput, setPendingInput] = useState('');
+  useEffect(() => {
+    if (!isRecording && transcript) {
+      setPendingInput((t) => (t ? `${t} ${transcript}` : transcript));
+    }
+  }, [isRecording, transcript]);
+
+  const { files, addFiles, removeFile, clear: clearFiles } = useFileUpload({
+    accept: ['image/*', '.png', '.jpg', '.jpeg', '.webp', '.heic', '.pdf'],
+    maxFiles: 6,
+    maxSizeMB: 12
+  });
+
+  const sendMessage = async (text: string) => {
+    if (!text && files.length === 0) return;
+
+    const userMsg: ChatMessage = {
+      id: crypto.randomUUID(),
+      role: 'user',
+      content: text.trim(),
+      attachments: files.map(f => ({ id: f.id, name: f.file.name, url: f.preview, type: f.file.type, size: f.file.size }))
+    };
+
+    setMessages(prev => [...prev, userMsg]);
+    setShowSuggestions(false);
+    setPendingInput('');
+    clearFiles();
+
+    // TODO: integrate your backend here. For now, fake a graceful thinking state + reply.
+    const thinkingId = crypto.randomUUID();
+    setMessages(prev => [...prev, { id: thinkingId, role: 'assistant', content: '•••', thinking: true }]);
+
+    // Simulated delay + example reply
+    setTimeout(() => {
+      setMessages(prev =>
+        prev.map(m => m.id === thinkingId ? {
+          id: thinkingId,
+          role: 'assistant',
+          content: "Lovely! Tell me about the room’s light and any fixed elements (floors, counters). You can upload a photo and I’ll analyze undertones. 🎨"
+        } : m)
+      );
+    }, 900);
+  };
+
+  const onChooseSuggestion = (s: string) => {
+    setPendingInput(s);
+    sendMessage(s);
+  };
+
+  const onMicToggle = () => (isRecording ? stop() : start());
+
   return (
-    <main className="mx-auto max-w-md px-4 py-8">
-      <h1 className="text-2xl font-semibold tracking-tight">Via</h1>
-      <p className="mt-2 text-sm text-muted-foreground">
-        Ask our friendly design assistant anything about your space. (Full chat coming soon.)
-      </p>
-      <div className="mt-6 rounded-2xl border p-4">
-        <p className="text-sm">Try: “Softer trim with Shoji White walls?”</p>
-      </div>
-    </main>
+    <div className="relative min-h-[100dvh] bg-[--via-peach-bg]">
+      {/* dreamy ambient top edge (already in repo) */}
+      <AmbientEdge className="pointer-events-none" />
+
+      <main className="container-xy py-6 md:py-10">
+        {/* Paint-chip card */}
+        <section
+          className={cn(
+            "via-card mx-auto shadow-card border border-[color-mix(in_oklab,var(--via-olive)15%,white)]",
+            "bg-[--via-panel] backdrop-blur-[1px]"
+          )}
+          aria-label="Via chat panel"
+        >
+          {/* Header / Greeting */}
+          <header className="p-6 md:p-8">
+            <h1
+              aria-live="polite"
+              className="font-display text-4xl md:text-5xl leading-tight text-[--via-ink] via-type-in"
+            >
+              {bootTyped || '‎'}
+            </h1>
+
+            <p className="mt-3 text-[15px] md:text-base text-[--via-ink-subtle]">
+              how can i help?
+            </p>
+
+            {showSuggestions && (
+              <div className="mt-5">
+                <PrefilledButtons
+                  items={[
+                    "design a palette",
+                    "talk about paint",
+                    "something else"
+                  ]}
+                  onPick={onChooseSuggestion}
+                />
+              </div>
+            )}
+          </header>
+
+          {/* Messages */}
+          <ChatContainer
+            className="px-3 sm:px-4 md:px-6"
+            messages={messages}
+          />
+
+          {/* Input Bar */}
+          <InputBar
+            className="p-3 sm:p-4 md:p-6 border-t border-[color-mix(in_oklab,var(--via-olive)12%,white)]"
+            value={pendingInput}
+            onChange={setPendingInput}
+            onSubmit={sendMessage}
+            onAttach={(fileList) => addFiles(fileList)}
+            attachments={files}
+            onRemoveAttachment={(id) => removeFile(id)}
+            micAvailable={speechSupported}
+            isRecording={isRecording}
+            onToggleMic={onMicToggle}
+          />
+        </section>
+      </main>
+    </div>
   );
 }
+

--- a/app/via/via.css
+++ b/app/via/via.css
@@ -1,0 +1,110 @@
+/* Page-level tokens for Via. Keeps within existing token system but scoped here. */
+:root {
+  --via-peach: oklch(0.91 0.04 45);      /* pastel peach */
+  --via-peach-2: oklch(0.985 0.01 95);   /* warm white top */
+  --via-peach-bg: linear-gradient(180deg, var(--via-peach) 0%, var(--via-peach-2) 48%);
+  --via-panel: oklch(0.985 0.005 95);    /* card surface */
+  --via-ink: oklch(0.2 0.01 270);        /* deep neutral for text */
+  --via-ink-subtle: oklch(0.42 0.02 270);
+  --via-olive: oklch(0.39 0.06 140);     /* brand olive (buttons) */
+  --via-olive-ink: oklch(0.96 0.01 110); /* text on olive */
+  --via-radius-xl: 28px;
+}
+
+/* Paint-chip silhouette: rounded left edge */
+.via-card {
+  border-radius: var(--via-radius-xl);
+  border-top-left-radius: 52px;
+  border-bottom-left-radius: 52px;
+  overflow: clip;
+  animation: via-enter 420ms var(--ease, cubic-bezier(.2,.8,.2,1)) both;
+}
+
+@keyframes via-enter {
+  from { opacity: 0; transform: translateY(8px) scale(.995); }
+  to   { opacity: 1; transform: translateY(0) scale(1); }
+}
+
+/* Type-in header effect */
+.via-type-in { white-space: pre; }
+.via-type-in::after {
+  content: ' ';
+  display: inline-block;
+  width: .55ch;
+  height: 1.1em;
+  vertical-align: -0.1em;
+  background: color-mix(in oklab, var(--via-ink) 35%, transparent);
+  margin-left: 2px;
+  border-radius: 2px;
+  animation: caret 900ms steps(1) infinite;
+}
+@keyframes caret { 50% { opacity: 0; } }
+
+/* Suggestion chips */
+.via-suggestion {
+  --bg: var(--via-olive);
+  --fg: var(--via-olive-ink);
+  background: var(--bg);
+  color: var(--fg);
+  border-radius: 9999px;
+  padding: 10px 16px;
+  font-weight: 600;
+  letter-spacing: .2px;
+  transition: transform .12s ease, box-shadow .12s ease, background .12s ease;
+  box-shadow: 0 2px 0 color-mix(in oklab, black 8%, transparent);
+}
+.via-suggestion:hover { transform: translateY(-1px); }
+.via-suggestion:active { transform: translateY(0); }
+
+/* Message bubbles */
+.via-bubble {
+  max-width: min(72ch, 92%);
+  border-radius: 16px;
+  padding: 10px 14px;
+  line-height: 1.45;
+  word-wrap: break-word;
+}
+.via-bubble--assistant {
+  background: white;
+  border: 1px solid color-mix(in oklab, var(--via-olive) 15%, white);
+}
+.via-bubble--user {
+  background: color-mix(in oklab, var(--via-olive) 92%, white);
+  color: var(--via-olive-ink);
+}
+
+/* Attachments */
+.via-attachments {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(72px, 1fr));
+  gap: 8px;
+  margin-top: 8px;
+}
+.via-attachments figure {
+  position: relative;
+  border-radius: 12px;
+  overflow: hidden;
+  border: 1px solid color-mix(in oklab, var(--via-olive) 25%, white);
+  background: white;
+}
+.via-attachments button.remove {
+  position: absolute;
+  top: 4px;
+  right: 4px;
+  background: color-mix(in oklab, black 8%, white);
+  border-radius: 8px;
+  padding: 2px 6px;
+}
+
+/* Input bar */
+.via-input {
+  background: oklch(.99 .004 95);
+  border-radius: 16px;
+  border: 1px solid color-mix(in oklab, var(--via-olive) 18%, white);
+}
+.via-input textarea {
+  resize: none;
+  min-height: 48px;
+  max-height: 168px;
+}
+

--- a/components/via/ChatContainer.tsx
+++ b/components/via/ChatContainer.tsx
@@ -1,0 +1,52 @@
+'use client';
+
+import React, { useEffect, useRef } from 'react';
+import { cn } from '@/lib/utils';
+import MessageBubble, { Attachment } from './MessageBubble';
+
+export type ChatMessage = {
+  id: string;
+  role: 'user' | 'assistant';
+  content: string;
+  attachments?: Attachment[];
+  thinking?: boolean;
+};
+
+export default function ChatContainer({
+  messages,
+  className
+}: {
+  messages: ChatMessage[];
+  className?: string;
+}) {
+  const endRef = useRef<HTMLDivElement | null>(null);
+
+  useEffect(() => {
+    endRef.current?.scrollIntoView({ behavior: 'smooth', block: 'end' });
+  }, [messages.length]);
+
+  return (
+    <section
+      className={cn(
+        'relative',
+        'min-h-[30dvh] max-h-[58dvh] md:max-h-[62dvh]',
+        'px-1 md:px-2',
+        'overflow-y-auto',
+        className
+      )}
+      aria-live="polite"
+      aria-label="Conversation"
+      role="log"
+    >
+      <div className="space-y-3 pb-4">
+        {messages.map(m => (
+          <MessageBubble key={m.id} role={m.role} attachments={m.attachments}>
+            {m.thinking ? 'Via is thinking…' : m.content}
+          </MessageBubble>
+        ))}
+        <div ref={endRef} />
+      </div>
+    </section>
+  );
+}
+

--- a/components/via/InputBar.tsx
+++ b/components/via/InputBar.tsx
@@ -1,0 +1,150 @@
+'use client';
+
+import React, { FormEvent, useEffect, useRef } from 'react';
+import { cn } from '@/lib/utils';
+import { MicIcon, MicOffIcon, PaperclipIcon, SendIcon } from './icons';
+
+export default function InputBar({
+  className,
+  value,
+  onChange,
+  onSubmit,
+  onAttach,
+  attachments,
+  onRemoveAttachment,
+  micAvailable,
+  isRecording,
+  onToggleMic
+}: {
+  className?: string;
+  value: string;
+  onChange: (v: string) => void;
+  onSubmit: (v: string) => void;
+  onAttach: (files: FileList) => void;
+  attachments: { id: string; name: string; url: string; type?: string; size?: number }[];
+  onRemoveAttachment: (id: string) => void;
+  micAvailable: boolean;
+  isRecording: boolean;
+  onToggleMic: () => void;
+}) {
+  const fileInput = useRef<HTMLInputElement | null>(null);
+  const onPick = () => fileInput.current?.click();
+
+  const handleSubmit = (e: FormEvent) => {
+    e.preventDefault();
+    onSubmit(value);
+  };
+
+  // textarea autoresize
+  const taRef = useRef<HTMLTextAreaElement | null>(null);
+  useEffect(() => {
+    const el = taRef.current;
+    if (!el) return;
+    el.style.height = '0px';
+    el.style.height = el.scrollHeight + 'px';
+  }, [value]);
+
+  return (
+    <footer className={cn('bg-transparent', className)}>
+      {attachments.length > 0 && (
+        <div className="mb-3">
+          <div className="via-attachments">
+            {attachments.map((a) => (
+              <figure key={a.id}>
+                {a.type?.startsWith('image/') ? (
+                  /* eslint-disable @next/next/no-img-element */
+                  <img src={a.url} alt={a.name} className="block w-full h-20 object-cover" />
+                ) : (
+                  <div className="h-20 grid place-items-center text-sm text-[--via-ink-subtle]">
+                    {a.name}
+                  </div>
+                )}
+                <button
+                  type="button"
+                  className="remove text-xs"
+                  onClick={() => onRemoveAttachment(a.id)}
+                  aria-label={`Remove ${a.name}`}
+                >
+                  ✕
+                </button>
+              </figure>
+            ))}
+          </div>
+        </div>
+      )}
+
+      <form onSubmit={handleSubmit} className="via-input grid grid-cols-[auto,1fr,auto,auto] gap-2 items-end p-2">
+        {/* Attach */}
+        <div className="pl-2 flex items-center">
+          <button
+            type="button"
+            className="p-2 rounded-md hover:bg-white/70"
+            onClick={onPick}
+            aria-label="Attach files"
+            title="Attach files"
+          >
+            <PaperclipIcon />
+          </button>
+          <input
+            ref={fileInput}
+            type="file"
+            multiple
+            className="hidden"
+            onChange={(e) => e.target.files && onAttach(e.target.files)}
+            accept="image/*,.pdf"
+          />
+        </div>
+
+        {/* Textarea */}
+        <div className="px-1">
+          <label htmlFor="via-input" className="sr-only">Message Via</label>
+          <textarea
+            id="via-input"
+            ref={taRef}
+            className="w-full bg-transparent outline-none text-[0.98rem] leading-[1.35] placeholder:text-[--via-ink-subtle]"
+            placeholder="type something to get started…"
+            value={value}
+            onChange={(e) => onChange(e.target.value)}
+            onKeyDown={(e) => {
+              if (e.key === 'Enter' && !e.shiftKey) {
+                e.preventDefault();
+                onSubmit(value);
+              }
+            }}
+          />
+        </div>
+
+        {/* Mic */}
+        <div className="flex items-center">
+          <button
+            type="button"
+            disabled={!micAvailable}
+            onClick={onToggleMic}
+            className={cn(
+              'p-2 rounded-md',
+              micAvailable ? 'hover:bg-white/70' : 'opacity-50 cursor-not-allowed'
+            )}
+            aria-pressed={isRecording}
+            aria-label={isRecording ? 'Stop recording' : 'Start recording'}
+            title={micAvailable ? (isRecording ? 'Stop recording' : 'Start recording') : 'Microphone not available'}
+          >
+            {isRecording ? <MicOffIcon /> : <MicIcon />}
+          </button>
+        </div>
+
+        {/* Send */}
+        <div className="pr-1 flex items-center">
+          <button
+            type="submit"
+            className="inline-flex items-center gap-1 px-3 py-2 rounded-md bg-[--via-olive] text-[--via-olive-ink] font-semibold hover:brightness-105 active:brightness-95"
+            aria-label="Send"
+          >
+            <SendIcon />
+            <span className="hidden sm:inline">Send</span>
+          </button>
+        </div>
+      </form>
+    </footer>
+  );
+}
+

--- a/components/via/MessageBubble.tsx
+++ b/components/via/MessageBubble.tsx
@@ -1,0 +1,52 @@
+'use client';
+
+import React from 'react';
+import { cn } from '@/lib/utils';
+
+export type Attachment = {
+  id: string;
+  name: string;
+  url: string;
+  type?: string;
+  size?: number;
+};
+
+export default function MessageBubble({
+  role,
+  children,
+  attachments
+}: {
+  role: 'user' | 'assistant';
+  children: React.ReactNode;
+  attachments?: Attachment[];
+}) {
+  const isUser = role === 'user';
+  return (
+    <div className={cn(
+      'via-bubble',
+      isUser ? 'via-bubble--user ml-auto' : 'via-bubble--assistant mr-auto'
+    )}>
+      <div className="whitespace-pre-wrap text-[0.97rem]">{children}</div>
+      {!!attachments?.length && (
+        <div className="via-attachments">
+          {attachments.map(file => {
+            const isImage = file.type?.startsWith('image/');
+            return (
+              <figure key={file.id}>
+                {isImage ? (
+                  /* eslint-disable @next/next/no-img-element */
+                  <img src={file.url} alt={file.name} className="block w-full h-20 object-cover" />
+                ) : (
+                  <div className="h-20 grid place-items-center text-sm text-[--via-ink-subtle]">
+                    {file.name}
+                  </div>
+                )}
+              </figure>
+            );
+          })}
+        </div>
+      )}
+    </div>
+  );
+}
+

--- a/components/via/PrefilledButtons.tsx
+++ b/components/via/PrefilledButtons.tsx
@@ -1,0 +1,31 @@
+'use client';
+
+import React from 'react';
+import { cn } from '@/lib/utils';
+
+export default function PrefilledButtons({
+  items,
+  onPick,
+  className
+}: {
+  items: string[];
+  onPick: (v: string) => void;
+  className?: string;
+}) {
+  return (
+    <div className={cn('flex flex-wrap gap-3', className)}>
+      {items.map((label) => (
+        <button
+          key={label}
+          className="via-suggestion"
+          onClick={() => onPick(label)}
+          aria-label={label}
+          type="button"
+        >
+          {label}
+        </button>
+      ))}
+    </div>
+  );
+}
+

--- a/components/via/icons.tsx
+++ b/components/via/icons.tsx
@@ -1,0 +1,43 @@
+'use client';
+import * as React from 'react';
+
+type P = React.SVGProps<SVGSVGElement> & { size?: number };
+const base = (props: P) => ({ width: props.size ?? 20, height: props.size ?? 20, strokeWidth: 1.8, ...props });
+
+export const MicIcon = (props: P) => (
+  <svg {...base(props)} viewBox="0 0 24 24" fill="none" stroke="currentColor" aria-hidden>
+    <rect x="9" y="2" width="6" height="11" rx="3" />
+    <path d="M5 11a7 7 0 0 0 14 0" />
+    <path d="M12 19v3" />
+  </svg>
+);
+
+export const MicOffIcon = (props: P) => (
+  <svg {...base(props)} viewBox="0 0 24 24" fill="none" stroke="currentColor" aria-hidden>
+    <rect x="9" y="2" width="6" height="11" rx="3" />
+    <path d="M5 11a7 7 0 0 0 12.5 2" />
+    <path d="M2 2l20 20" />
+  </svg>
+);
+
+export const PaperclipIcon = (props: P) => (
+  <svg {...base(props)} viewBox="0 0 24 24" fill="none" stroke="currentColor" aria-hidden>
+    <path d="M21 12.5l-7.5 7.5a6 6 0 1 1-8.5-8.5l9.5-9.5a4 4 0 0 1 5.7 5.6L9 19a2.5 2.5 0 1 1-3.5-3.5L16 5" />
+  </svg>
+);
+
+export const SendIcon = (props: P) => (
+  <svg {...base(props)} viewBox="0 0 24 24" fill="none" stroke="currentColor" aria-hidden>
+    <path d="M22 2L11 13" />
+    <path d="M22 2L15 22l-4-9-9-4L22 2z" />
+  </svg>
+);
+
+export const ImageIcon = (props: P) => (
+  <svg {...base(props)} viewBox="0 0 24 24" fill="none" stroke="currentColor" aria-hidden>
+    <rect x="3" y="5" width="18" height="14" rx="2" />
+    <circle cx="8.5" cy="10.5" r="1.8" />
+    <path d="M21 16l-5.5-5.5L9 17l-2-2-4 4" />
+  </svg>
+);
+

--- a/hooks/useFileUpload.ts
+++ b/hooks/useFileUpload.ts
@@ -1,0 +1,46 @@
+'use client';
+
+import { useCallback, useState } from 'react';
+
+type Upload = {
+  id: string;
+  file: File;
+  preview: string;
+};
+
+export default function useFileUpload(opts?: {
+  accept?: string[];
+  maxFiles?: number;
+  maxSizeMB?: number;
+}) {
+  const { accept = [], maxFiles = 6, maxSizeMB = 12 } = opts ?? {};
+  const [files, setFiles] = useState<Upload[]>([]);
+
+  const addFiles = useCallback((list: FileList) => {
+    const incoming = Array.from(list);
+    const accepted = incoming.filter((f) => {
+      const okType = accept.length === 0 || accept.some(a => {
+        if (a.endsWith('/*')) return f.type.startsWith(a.slice(0, -1));
+        if (a.startsWith('.')) return f.name.toLowerCase().endsWith(a);
+        return f.type === a;
+      });
+      const okSize = f.size <= maxSizeMB * 1024 * 1024;
+      return okType && okSize;
+    });
+    const next = [...files];
+    for (const f of accepted) {
+      if (next.length >= maxFiles) break;
+      next.push({ id: crypto.randomUUID(), file: f, preview: URL.createObjectURL(f) });
+    }
+    setFiles(next);
+  }, [files, accept, maxFiles, maxSizeMB]);
+
+  const removeFile = useCallback((id: string) => {
+    setFiles(prev => prev.filter(f => f.id !== id));
+  }, []);
+
+  const clear = useCallback(() => setFiles([]), []);
+
+  return { files, addFiles, removeFile, clear };
+}
+


### PR DESCRIPTION
## Summary
- add Via chat page with styled chat UI
- include speech and file upload hooks for attachments
- build icons and components for suggestions and input bar

## Testing
- `npm run lint`
- `npm test` *(fails: browserType.launch: Executable doesn't exist)*
- `curl -I http://localhost:3002/via`


------
https://chatgpt.com/codex/tasks/task_e_689eb5c8c3708322aee87dcb9e533727