### PR TITLE
Map file uploads to InputBar format

### DIFF
--- a/app/via/page.tsx
+++ b/app/via/page.tsx
@@ -134,7 +134,13 @@ export default function ViaPage() {
             onChange={setPendingInput}
             onSubmit={sendMessage}
             onAttach={(fileList) => addFiles(fileList)}
-            attachments={files}
+            attachments={files.map(f => ({
+              id: f.id,
+              name: f.file.name,
+              url: f.preview,
+              type: f.file.type,
+              size: f.file.size,
+            }))}
             onRemoveAttachment={(id) => removeFile(id)}
             micAvailable={speechSupported}
             isRecording={isRecording}


### PR DESCRIPTION
## Summary
- Map uploaded files into InputBar's expected attachment shape in Via page

## Testing
- `npm test` *(fails: browserType.launch: Executable doesn't exist)*
- `npm run lint`
- `npm run build` *(fails: OPENAI_API_KEY environment variable is missing)*

------
https://chatgpt.com/codex/tasks/task_e_689eb9da9a6c8322b7d4a5ddc0ed50eb