### PR TITLE
feat: add Via chat UI with voice and image analysis

### DIFF
--- a/app/via/page.tsx
+++ b/app/via/page.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useMemo, useRef, useState } from 'react';
 import './via.css';
 import AmbientEdge from '@/components/ui/ambient-edge';
 import PrefilledButtons from '@/components/via/PrefilledButtons';
@@ -8,143 +8,221 @@ import ChatContainer, { ChatMessage } from '@/components/via/ChatContainer';
 import InputBar from '@/components/via/InputBar';
 import useSpeech from '@/hooks/useSpeech';
 import useFileUpload from '@/hooks/useFileUpload';
+import useVoiceOut from '@/hooks/useVoiceOut';
 import { cn } from '@/lib/utils';
 
 export default function ViaPage() {
+  // Conversation
   const [messages, setMessages] = useState<ChatMessage[]>([]);
-  const [bootTyped, setBootTyped] = useState('');
   const [showSuggestions, setShowSuggestions] = useState(true);
 
-  // Type-in intro "hi. i'm Via," once on mount
+  // Intro type-in
+  const [bootTyped, setBootTyped] = useState('');
   useEffect(() => {
-    const intro = "hi. i’m Via,";
+    const intro = 'hi. i’m Via,';
     let i = 0;
     const id = setInterval(() => {
       setBootTyped(intro.slice(0, ++i));
       if (i === intro.length) clearInterval(id);
-    }, 35);
+    }, 32);
     return () => clearInterval(id);
   }, []);
 
-  const { isRecording, start, stop, transcript, supported: speechSupported } = useSpeech();
+  // Speech in/out
+  const stt = useSpeech();
+  const { speakEnabled, toggleSpeak, speak } = useVoiceOut({ voiceHint: 'female' });
 
-  // When transcript updates (recording ended), push into input
+  // Input and files
   const [pendingInput, setPendingInput] = useState('');
-  useEffect(() => {
-    if (!isRecording && transcript) {
-      setPendingInput((t) => (t ? `${t} ${transcript}` : transcript));
-    }
-  }, [isRecording, transcript]);
-
   const { files, addFiles, removeFile, clear: clearFiles } = useFileUpload({
     accept: ['image/*', '.png', '.jpg', '.jpeg', '.webp', '.heic', '.pdf'],
     maxFiles: 6,
-    maxSizeMB: 12
+    maxSizeMB: 12,
+    makeDataUrl: true, // enables /api/vision/analyze via data URL
   });
 
-  const sendMessage = async (text: string) => {
-    if (!text && files.length === 0) return;
+  // When mic finishes, push transcript into input
+  useEffect(() => {
+    if (!stt.isRecording && stt.transcript) {
+      setPendingInput((t) => (t ? `${t} ${stt.transcript}` : stt.transcript));
+    }
+  }, [stt.isRecording, stt.transcript]);
 
-    const userMsg: ChatMessage = {
-      id: crypto.randomUUID(),
+  // Helpers
+  const push = (m: ChatMessage) => setMessages((prev) => [...prev, m]);
+  const replace = (id: string, updater: (m: ChatMessage) => ChatMessage) =>
+    setMessages((prev) => prev.map((m) => (m.id === id ? updater(m) : m)));
+
+  // ---- Smart image analysis \u2192 callouts (client-side before main answer)
+  async function analyzeImages() {
+    const imageUploads = files.filter((f) => f.file.type.startsWith('image/'));
+    if (imageUploads.length === 0) return null;
+
+    // Show a placeholder "Analyzing\u2026" callout
+    const calloutId = crypto.randomUUID();
+    push({
+      id: calloutId,
+      role: 'assistant',
+      kind: 'callouts',
+      content: 'Analyzing your images…',
+      callouts: [{ label: 'Analyzing…', tone: 'info' }],
+    });
+
+    try {
+      const results = await Promise.all(
+        imageUploads.map(async (f) => {
+          const r = await fetch('/api/vision/analyze', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ imageUrl: f.dataUrl }), // data URL supported by OpenAI
+          });
+          const j = await r.json();
+          return { name: f.file.name, notes: j?.notes || '' };
+        })
+      );
+
+      // Convert notes \u2192 concise chips (first sentences)
+      const chips = results.flatMap((r) => {
+        const first = (r.notes || '').split(/(?<=\.)\s+/)[0]?.trim();
+        return first ? [{ label: first, tone: 'neutral' as const }] : [];
+      });
+
+      replace(calloutId, (m) => ({
+        ...m,
+        content: 'Image insights',
+        callouts: chips.length ? chips : [{ label: 'No strong undertones detected.', tone: 'neutral' }],
+      }));
+
+      return results;
+    } catch (e) {
+      replace(calloutId, (m) => ({
+        ...m,
+        content: 'Image analysis failed',
+        callouts: [{ label: 'Could not analyze images right now.', tone: 'warn' }],
+      }));
+      return null;
+    }
+  }
+
+  // ---- Send message \u2192 wire /api/via/answer
+  const sendMessage = async (text: string) => {
+    const trimmed = text.trim();
+    if (!trimmed && files.length === 0) return;
+
+    setShowSuggestions(false);
+
+    // Push user message
+    const userMsgId = crypto.randomUUID();
+    push({
+      id: userMsgId,
       role: 'user',
-      content: text.trim(),
-      attachments: files.map(f => ({ id: f.id, name: f.file.name, url: f.preview, type: f.file.type, size: f.file.size }))
+      content: trimmed,
+      attachments: files.map((f) => ({
+        id: f.id, name: f.file.name, url: f.preview, type: f.file.type, size: f.file.size
+      })),
+    });
+
+    // Run image analysis (shows callouts as it goes)
+    const vision = await analyzeImages();
+
+    // Prepare context for Via
+    const context = {
+      imageSummaries: vision,
+      filenames: files.map((f) => f.file.name),
     };
 
-    setMessages(prev => [...prev, userMsg]);
-    setShowSuggestions(false);
+    // Clear composer
     setPendingInput('');
     clearFiles();
 
-    // TODO: integrate your backend here. For now, fake a graceful thinking state + reply.
+    // Thinking placeholder
     const thinkingId = crypto.randomUUID();
-    setMessages(prev => [...prev, { id: thinkingId, role: 'assistant', content: '•••', thinking: true }]);
+    push({ id: thinkingId, role: 'assistant', content: '•••', thinking: true });
 
-    // Simulated delay + example reply
-    setTimeout(() => {
-      setMessages(prev =>
-        prev.map(m => m.id === thinkingId ? {
-          id: thinkingId,
-          role: 'assistant',
-          content: "Lovely! Tell me about the room’s light and any fixed elements (floors, counters). You can upload a photo and I’ll analyze undertones. 🎨"
-        } : m)
-      );
-    }, 900);
+    try {
+      const r = await fetch('/api/via/answer', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ question: trimmed, context }),
+      });
+      const j = await r.json();
+      const answer = (j?.answer || '').trim();
+
+      replace(thinkingId, () => ({
+        id: thinkingId,
+        role: 'assistant',
+        content: answer || "I couldn't find an answer just now, but I'm here to help with color direction and prep tips.",
+      }));
+
+      // Optional: speak the reply
+      if (speakEnabled && answer) speak(answer);
+    } catch {
+      replace(thinkingId, () => ({
+        id: thinkingId,
+        role: 'assistant',
+        content: 'Hmm, something went wrong reaching my paint brain. Try again in a moment.',
+      }));
+    }
   };
-
-  const onChooseSuggestion = (s: string) => {
-    setPendingInput(s);
-    sendMessage(s);
-  };
-
-  const onMicToggle = () => (isRecording ? stop() : start());
 
   return (
-    <div className="relative min-h-[100dvh] bg-[--via-peach-bg]">
-      {/* dreamy ambient top edge (already in repo) */}
+    <div className={cn('theme-via relative min-h-[100dvh]')}>
+      {/* ambient glow */}
       <AmbientEdge className="pointer-events-none" />
 
       <main className="container-xy py-6 md:py-10">
         {/* Paint-chip card */}
         <section
           className={cn(
-            "via-card mx-auto shadow-card border border-[color-mix(in_oklab,var(--via-olive)15%,white)]",
-            "bg-[--via-panel] backdrop-blur-[1px]"
+            'via-card mx-auto shadow-card border border-[color-mix(in_oklab,var(--via-olive)15%,white)]',
+            'bg-[--via-panel] backdrop-blur-[1px]'
           )}
           aria-label="Via chat panel"
         >
-          {/* Header / Greeting */}
-          <header className="p-6 md:p-8">
-            <h1
-              aria-live="polite"
-              className="font-display text-4xl md:text-5xl leading-tight text-[--via-ink] via-type-in"
+          {/* Header */}
+          <header className="p-6 md:p-8 flex items-start justify-between gap-4">
+            <div>
+              <h1 className="font-display text-4xl md:text-5xl leading-tight text-[--via-ink] via-type-in" aria-live="polite">
+                {bootTyped || '‎'}
+              </h1>
+              <p className="mt-3 text-[15px] md:text-base text-[--via-ink-subtle]">how can i help?</p>
+              {showSuggestions && (
+                <div className="mt-5">
+                  <PrefilledButtons
+                    items={['design a palette', 'talk about paint', 'something else']}
+                    onPick={(s) => { setPendingInput(s); sendMessage(s); }}
+                  />
+                </div>
+              )}
+            </div>
+
+            {/* speaker toggle */}
+            <button
+              type="button"
+              className="via-chip px-3 py-2 mt-1"
+              onClick={toggleSpeak}
+              aria-pressed={speakEnabled}
+              title={speakEnabled ? 'Disable voice' : 'Enable voice'}
             >
-              {bootTyped || '‎'}
-            </h1>
-
-            <p className="mt-3 text-[15px] md:text-base text-[--via-ink-subtle]">
-              how can i help?
-            </p>
-
-            {showSuggestions && (
-              <div className="mt-5">
-                <PrefilledButtons
-                  items={[
-                    "design a palette",
-                    "talk about paint",
-                    "something else"
-                  ]}
-                  onPick={onChooseSuggestion}
-                />
-              </div>
-            )}
+              {speakEnabled ? '🔊 voice on' : '🔈 voice off'}
+            </button>
           </header>
 
           {/* Messages */}
-          <ChatContainer
-            className="px-3 sm:px-4 md:px-6"
-            messages={messages}
-          />
+          <ChatContainer className="px-3 sm:px-4 md:px-6" messages={messages} />
 
-          {/* Input Bar */}
+          {/* Composer */}
           <InputBar
             className="p-3 sm:p-4 md:p-6 border-t border-[color-mix(in_oklab,var(--via-olive)12%,white)]"
             value={pendingInput}
             onChange={setPendingInput}
             onSubmit={sendMessage}
-            onAttach={(fileList) => addFiles(fileList)}
-            attachments={files.map(f => ({
-              id: f.id,
-              name: f.file.name,
-              url: f.preview,
-              type: f.file.type,
-              size: f.file.size,
-            }))}
+            onAttach={(list) => addFiles(list)}
+            attachments={files.map(f => ({ id: f.id, name: f.file.name, url: f.preview, type: f.file.type, size: f.file.size }))}
             onRemoveAttachment={(id) => removeFile(id)}
-            micAvailable={speechSupported}
-            isRecording={isRecording}
-            onToggleMic={onMicToggle}
+            micAvailable={stt.supported}
+            isRecording={stt.isRecording}
+            onToggleMic={() => (stt.isRecording ? stt.stop() : stt.start())}
           />
         </section>
       </main>

--- a/app/via/via.css
+++ b/app/via/via.css
@@ -1,60 +1,66 @@
-/* Page-level tokens for Via. Keeps within existing token system but scoped here. */
-:root {
-  --via-peach: oklch(0.91 0.04 45);      /* pastel peach */
-  --via-peach-2: oklch(0.985 0.01 95);   /* warm white top */
-  --via-peach-bg: linear-gradient(180deg, var(--via-peach) 0%, var(--via-peach-2) 48%);
-  --via-panel: oklch(0.985 0.005 95);    /* card surface */
-  --via-ink: oklch(0.2 0.01 270);        /* deep neutral for text */
-  --via-ink-subtle: oklch(0.42 0.02 270);
-  --via-olive: oklch(0.39 0.06 140);     /* brand olive (buttons) */
-  --via-olive-ink: oklch(0.96 0.01 110); /* text on olive */
-  --via-radius-xl: 28px;
+/* ---------- Brand-scoped tokens for /via ---------- */
+.theme-via {
+  /* Background: pastel peach → warm white */
+  --via-peach: oklch(0.92 0.05 45);
+  --via-peach-2: oklch(0.99 0.01 95);
+  --via-bg: linear-gradient(180deg, var(--via-peach) 0%, var(--via-peach-2) 52%);
+  background: var(--via-bg);
+  /* Card surface + text */
+  --via-panel: oklch(0.985 0.005 95);
+  --via-ink: oklch(0.20 0.01 272);
+  --via-ink-subtle: oklch(0.42 0.02 272);
+  /* Action (olive) */
+  --via-olive: oklch(0.39 0.06 140);
+  --via-olive-ink: oklch(0.98 0.01 110);
+
+  /* Also map to global tokens so components stay consistent */
+  --brand: var(--via-olive);
+  --color-bg: var(--via-peach-2);
+  --color-surface: var(--via-panel);
+  --color-fg: var(--via-ink);
+  --color-fg-muted: var(--via-ink-subtle);
+  --color-border: color-mix(in oklab, var(--via-olive) 16%, white);
 }
 
-/* Paint-chip silhouette: rounded left edge */
+/* Paint-chip silhouette + enter animation */
 .via-card {
-  border-radius: var(--via-radius-xl);
+  border-radius: 28px;
   border-top-left-radius: 52px;
   border-bottom-left-radius: 52px;
   overflow: clip;
-  animation: via-enter 420ms var(--ease, cubic-bezier(.2,.8,.2,1)) both;
+  animation: via-enter 420ms cubic-bezier(.2,.8,.2,1) both;
 }
-
 @keyframes via-enter {
   from { opacity: 0; transform: translateY(8px) scale(.995); }
   to   { opacity: 1; transform: translateY(0) scale(1); }
 }
 
-/* Type-in header effect */
+/* Type-in effect for "hi, i’m Via," */
 .via-type-in { white-space: pre; }
 .via-type-in::after {
   content: ' ';
   display: inline-block;
-  width: .55ch;
-  height: 1.1em;
-  vertical-align: -0.1em;
+  width: .55ch; height: 1.1em; vertical-align: -0.1em;
   background: color-mix(in oklab, var(--via-ink) 35%, transparent);
-  margin-left: 2px;
-  border-radius: 2px;
+  margin-left: 2px; border-radius: 2px;
   animation: caret 900ms steps(1) infinite;
 }
 @keyframes caret { 50% { opacity: 0; } }
 
-/* Suggestion chips */
-.via-suggestion {
-  --bg: var(--via-olive);
-  --fg: var(--via-olive-ink);
-  background: var(--bg);
-  color: var(--fg);
-  border-radius: 9999px;
-  padding: 10px 16px;
+/* Chips */
+.via-chip {
+  background: color-mix(in oklab, var(--via-olive) 90%, white);
+  color: var(--via-olive-ink);
+  border-radius: 999px;
   font-weight: 600;
   letter-spacing: .2px;
-  transition: transform .12s ease, box-shadow .12s ease, background .12s ease;
   box-shadow: 0 2px 0 color-mix(in oklab, black 8%, transparent);
+  transition: transform .12s ease, filter .12s ease;
 }
-.via-suggestion:hover { transform: translateY(-1px); }
-.via-suggestion:active { transform: translateY(0); }
+.via-chip:hover { transform: translateY(-1px); }
+
+/* Suggestion buttons use .via-chip via component */
+.via-suggestion { composes: via-chip; padding: 10px 16px; }
 
 /* Message bubbles */
 .via-bubble {
@@ -73,38 +79,39 @@
   color: var(--via-olive-ink);
 }
 
-/* Attachments */
+/* Callouts (image insights) */
+.via-callouts {
+  display: flex; flex-wrap: wrap; gap: 8px; margin-top: 8px;
+}
+.via-callouts .pill {
+  padding: 8px 12px; border-radius: 999px; font-size: 13px; font-weight: 600;
+  border: 1px solid color-mix(in oklab, var(--via-olive) 22%, white);
+  background: oklch(.995 .002 95);
+}
+.via-callouts .pill.warn { background: #fff6ed; border-color: #fed7aa; }
+.via-callouts .pill.info { background: #eef2ff; border-color: #c7d2fe; }
+
+/* Attachments grid */
 .via-attachments {
-  display: grid;
-  grid-template-columns: repeat(auto-fill, minmax(72px, 1fr));
-  gap: 8px;
-  margin-top: 8px;
+  display: grid; grid-template-columns: repeat(auto-fill, minmax(72px, 1fr));
+  gap: 8px; margin-top: 8px;
 }
 .via-attachments figure {
-  position: relative;
-  border-radius: 12px;
-  overflow: hidden;
+  position: relative; border-radius: 12px; overflow: hidden;
   border: 1px solid color-mix(in oklab, var(--via-olive) 25%, white);
   background: white;
 }
 .via-attachments button.remove {
-  position: absolute;
-  top: 4px;
-  right: 4px;
+  position: absolute; top: 4px; right: 4px;
   background: color-mix(in oklab, black 8%, white);
-  border-radius: 8px;
-  padding: 2px 6px;
+  border-radius: 8px; padding: 2px 6px;
 }
 
-/* Input bar */
+/* Input */
 .via-input {
   background: oklch(.99 .004 95);
   border-radius: 16px;
   border: 1px solid color-mix(in oklab, var(--via-olive) 18%, white);
 }
-.via-input textarea {
-  resize: none;
-  min-height: 48px;
-  max-height: 168px;
-}
+.via-input textarea { resize: none; min-height: 48px; max-height: 168px; }
 

--- a/components/via/ChatContainer.tsx
+++ b/components/via/ChatContainer.tsx
@@ -10,6 +10,8 @@ export type ChatMessage = {
   content: string;
   attachments?: Attachment[];
   thinking?: boolean;
+  kind?: 'text' | 'callouts';
+  callouts?: { label: string; tone?: 'neutral' | 'warn' | 'info' }[];
 };
 
 export default function ChatContainer({
@@ -20,27 +22,21 @@ export default function ChatContainer({
   className?: string;
 }) {
   const endRef = useRef<HTMLDivElement | null>(null);
-
-  useEffect(() => {
-    endRef.current?.scrollIntoView({ behavior: 'smooth', block: 'end' });
-  }, [messages.length]);
+  useEffect(() => { endRef.current?.scrollIntoView({ behavior: 'smooth', block: 'end' }); }, [messages.length]);
 
   return (
     <section
-      className={cn(
-        'relative',
-        'min-h-[30dvh] max-h-[58dvh] md:max-h-[62dvh]',
-        'px-1 md:px-2',
-        'overflow-y-auto',
-        className
-      )}
-      aria-live="polite"
-      aria-label="Conversation"
-      role="log"
+      className={cn('relative min-h-[30dvh] max-h-[58dvh] md:max-h-[62dvh] px-1 md:px-2 overflow-y-auto', className)}
+      aria-live="polite" aria-label="Conversation" role="log"
     >
       <div className="space-y-3 pb-4">
         {messages.map(m => (
-          <MessageBubble key={m.id} role={m.role} attachments={m.attachments}>
+          <MessageBubble
+            key={m.id}
+            role={m.role}
+            callouts={m.kind === 'callouts' ? m.callouts : undefined}
+            attachments={m.attachments}
+          >
             {m.thinking ? 'Via is thinking…' : m.content}
           </MessageBubble>
         ))}

--- a/components/via/InputBar.tsx
+++ b/components/via/InputBar.tsx
@@ -2,7 +2,6 @@
 
 import React, { FormEvent, useEffect, useRef } from 'react';
 import { cn } from '@/lib/utils';
-import { MicIcon, MicOffIcon, PaperclipIcon, SendIcon } from './icons';
 
 export default function InputBar({
   className,
@@ -30,18 +29,13 @@ export default function InputBar({
   const fileInput = useRef<HTMLInputElement | null>(null);
   const onPick = () => fileInput.current?.click();
 
-  const handleSubmit = (e: FormEvent) => {
-    e.preventDefault();
-    onSubmit(value);
-  };
+  const handleSubmit = (e: FormEvent) => { e.preventDefault(); onSubmit(value); };
 
-  // textarea autoresize
+  // autoresize
   const taRef = useRef<HTMLTextAreaElement | null>(null);
   useEffect(() => {
-    const el = taRef.current;
-    if (!el) return;
-    el.style.height = '0px';
-    el.style.height = el.scrollHeight + 'px';
+    const el = taRef.current; if (!el) return;
+    el.style.height = '0px'; el.style.height = el.scrollHeight + 'px';
   }, [value]);
 
   return (
@@ -52,95 +46,53 @@ export default function InputBar({
             {attachments.map((a) => (
               <figure key={a.id}>
                 {a.type?.startsWith('image/') ? (
-                  /* eslint-disable @next/next/no-img-element */
+                  // eslint-disable-next-line @next/next/no-img-element
                   <img src={a.url} alt={a.name} className="block w-full h-20 object-cover" />
                 ) : (
-                  <div className="h-20 grid place-items-center text-sm text-[--via-ink-subtle]">
-                    {a.name}
-                  </div>
+                  <div className="h-20 grid place-items-center text-sm text-[--via-ink-subtle]">{a.name}</div>
                 )}
-                <button
-                  type="button"
-                  className="remove text-xs"
-                  onClick={() => onRemoveAttachment(a.id)}
-                  aria-label={`Remove ${a.name}`}
-                >
-                  ✕
-                </button>
+                <button type="button" className="remove text-xs" onClick={() => onRemoveAttachment(a.id)} aria-label={`Remove ${a.name}`}>✕</button>
               </figure>
             ))}
           </div>
         </div>
       )}
 
-      <form onSubmit={handleSubmit} className="via-input grid grid-cols-[auto,1fr,auto,auto] gap-2 items-end p-2">
+      <form onSubmit={handleSubmit} className="via-input grid grid-cols-[auto,1fr,auto] gap-2 items-end p-2">
         {/* Attach */}
         <div className="pl-2 flex items-center">
-          <button
-            type="button"
-            className="p-2 rounded-md hover:bg-white/70"
-            onClick={onPick}
-            aria-label="Attach files"
-            title="Attach files"
-          >
-            <PaperclipIcon />
-          </button>
-          <input
-            ref={fileInput}
-            type="file"
-            multiple
-            className="hidden"
-            onChange={(e) => e.target.files && onAttach(e.target.files)}
-            accept="image/*,.pdf"
-          />
+          <button type="button" className="p-2 rounded-md hover:bg-white/70" onClick={onPick} aria-label="Attach files" title="Attach files">📎</button>
+          <input ref={fileInput} type="file" multiple className="hidden" onChange={(e) => e.target.files && onAttach(e.target.files)} accept="image/*,.pdf" />
         </div>
 
         {/* Textarea */}
         <div className="px-1">
           <label htmlFor="via-input" className="sr-only">Message Via</label>
           <textarea
-            id="via-input"
-            ref={taRef}
+            id="via-input" ref={taRef}
             className="w-full bg-transparent outline-none text-[0.98rem] leading-[1.35] placeholder:text-[--via-ink-subtle]"
             placeholder="type something to get started…"
-            value={value}
-            onChange={(e) => onChange(e.target.value)}
-            onKeyDown={(e) => {
-              if (e.key === 'Enter' && !e.shiftKey) {
-                e.preventDefault();
-                onSubmit(value);
-              }
-            }}
+            value={value} onChange={(e) => onChange(e.target.value)}
+            onKeyDown={(e) => { if (e.key === 'Enter' && !e.shiftKey) { e.preventDefault(); onSubmit(value); } }}
           />
         </div>
 
-        {/* Mic */}
-        <div className="flex items-center">
+        {/* Mic + Send */}
+        <div className="pr-1 flex items-center gap-1">
           <button
             type="button"
             disabled={!micAvailable}
             onClick={onToggleMic}
-            className={cn(
-              'p-2 rounded-md',
-              micAvailable ? 'hover:bg-white/70' : 'opacity-50 cursor-not-allowed'
-            )}
+            className={cn('p-2 rounded-md', micAvailable ? 'hover:bg-white/70' : 'opacity-50 cursor-not-allowed')}
             aria-pressed={isRecording}
             aria-label={isRecording ? 'Stop recording' : 'Start recording'}
             title={micAvailable ? (isRecording ? 'Stop recording' : 'Start recording') : 'Microphone not available'}
           >
-            {isRecording ? <MicOffIcon /> : <MicIcon />}
+            {isRecording ? '🛑🎙️' : '🎙️'}
           </button>
-        </div>
 
-        {/* Send */}
-        <div className="pr-1 flex items-center">
-          <button
-            type="submit"
-            className="inline-flex items-center gap-1 px-3 py-2 rounded-md bg-[--via-olive] text-[--via-olive-ink] font-semibold hover:brightness-105 active:brightness-95"
-            aria-label="Send"
-          >
-            <SendIcon />
-            <span className="hidden sm:inline">Send</span>
+          <button type="submit" className="inline-flex items-center gap-1 px-3 py-2 rounded-md bg-[--via-olive] text-[--via-olive-ink] font-semibold hover:brightness-105 active:brightness-95" aria-label="Send">
+            ➤ <span className="hidden sm:inline">Send</span>
           </button>
         </div>
       </form>

--- a/components/via/MessageBubble.tsx
+++ b/components/via/MessageBubble.tsx
@@ -14,32 +14,38 @@ export type Attachment = {
 export default function MessageBubble({
   role,
   children,
-  attachments
+  attachments,
+  callouts,
 }: {
   role: 'user' | 'assistant';
   children: React.ReactNode;
   attachments?: Attachment[];
+  callouts?: { label: string; tone?: 'neutral' | 'warn' | 'info' }[];
 }) {
   const isUser = role === 'user';
   return (
-    <div className={cn(
-      'via-bubble',
-      isUser ? 'via-bubble--user ml-auto' : 'via-bubble--assistant mr-auto'
-    )}>
+    <div className={cn('via-bubble', isUser ? 'via-bubble--user ml-auto' : 'via-bubble--assistant mr-auto')}>
       <div className="whitespace-pre-wrap text-[0.97rem]">{children}</div>
+
+      {!!callouts?.length && (
+        <div className="via-callouts">
+          {callouts.map((c, i) => (
+            <span key={i} className={cn('pill', c.tone)}>{c.label}</span>
+          ))}
+        </div>
+      )}
+
       {!!attachments?.length && (
         <div className="via-attachments">
-          {attachments.map(file => {
+          {attachments.map((file) => {
             const isImage = file.type?.startsWith('image/');
             return (
               <figure key={file.id}>
                 {isImage ? (
-                  /* eslint-disable @next/next/no-img-element */
+                  // eslint-disable-next-line @next/next/no-img-element
                   <img src={file.url} alt={file.name} className="block w-full h-20 object-cover" />
                 ) : (
-                  <div className="h-20 grid place-items-center text-sm text-[--via-ink-subtle]">
-                    {file.name}
-                  </div>
+                  <div className="h-20 grid place-items-center text-sm text-[--via-ink-subtle]">{file.name}</div>
                 )}
               </figure>
             );

--- a/components/via/PrefilledButtons.tsx
+++ b/components/via/PrefilledButtons.tsx
@@ -1,27 +1,14 @@
 'use client';
-
 import React from 'react';
 import { cn } from '@/lib/utils';
 
 export default function PrefilledButtons({
-  items,
-  onPick,
-  className
-}: {
-  items: string[];
-  onPick: (v: string) => void;
-  className?: string;
-}) {
+  items, onPick, className
+}: { items: string[]; onPick: (v: string) => void; className?: string; }) {
   return (
     <div className={cn('flex flex-wrap gap-3', className)}>
       {items.map((label) => (
-        <button
-          key={label}
-          className="via-suggestion"
-          onClick={() => onPick(label)}
-          aria-label={label}
-          type="button"
-        >
+        <button key={label} type="button" className="via-chip px-4 py-2" onClick={() => onPick(label)} aria-label={label}>
           {label}
         </button>
       ))}

--- a/hooks/useFileUpload.ts
+++ b/hooks/useFileUpload.ts
@@ -5,40 +5,56 @@ import { useCallback, useState } from 'react';
 type Upload = {
   id: string;
   file: File;
-  preview: string;
+  preview: string; // object URL for <img>
+  dataUrl?: string; // base64 data URL for vision API
 };
 
 export default function useFileUpload(opts?: {
   accept?: string[];
   maxFiles?: number;
   maxSizeMB?: number;
+  makeDataUrl?: boolean; // when true, generate base64 data URL for images
 }) {
-  const { accept = [], maxFiles = 6, maxSizeMB = 12 } = opts ?? {};
+  const { accept = [], maxFiles = 6, maxSizeMB = 12, makeDataUrl = false } = opts ?? {};
   const [files, setFiles] = useState<Upload[]>([]);
 
-  const addFiles = useCallback((list: FileList) => {
-    const incoming = Array.from(list);
-    const accepted = incoming.filter((f) => {
-      const okType = accept.length === 0 || accept.some(a => {
-        if (a.endsWith('/*')) return f.type.startsWith(a.slice(0, -1));
-        if (a.startsWith('.')) return f.name.toLowerCase().endsWith(a);
-        return f.type === a;
-      });
-      const okSize = f.size <= maxSizeMB * 1024 * 1024;
-      return okType && okSize;
+  const matches = (f: File) => {
+    if (accept.length === 0) return true;
+    return accept.some((a) => {
+      if (a.endsWith('/*')) return f.type.startsWith(a.slice(0, -1));
+      if (a.startsWith('.')) return f.name.toLowerCase().endsWith(a);
+      return f.type === a;
     });
+  };
+
+  const toDataUrl = (file: File) =>
+    new Promise<string>((resolve) => {
+      const reader = new FileReader();
+      reader.onload = () => resolve(reader.result as string);
+      reader.readAsDataURL(file);
+    });
+
+  const addFiles = useCallback(async (list: FileList) => {
+    const incoming = Array.from(list);
+    const accepted = incoming.filter((f) => matches(f) && f.size <= (maxSizeMB * 1024 * 1024));
     const next = [...files];
+
     for (const f of accepted) {
       if (next.length >= maxFiles) break;
-      next.push({ id: crypto.randomUUID(), file: f, preview: URL.createObjectURL(f) });
+      const upload: Upload = {
+        id: crypto.randomUUID(),
+        file: f,
+        preview: URL.createObjectURL(f),
+      };
+      if (makeDataUrl && f.type.startsWith('image/')) {
+        upload.dataUrl = await toDataUrl(f);
+      }
+      next.push(upload);
     }
     setFiles(next);
-  }, [files, accept, maxFiles, maxSizeMB]);
+  }, [files, maxFiles, maxSizeMB, makeDataUrl]);
 
-  const removeFile = useCallback((id: string) => {
-    setFiles(prev => prev.filter(f => f.id !== id));
-  }, []);
-
+  const removeFile = useCallback((id: string) => setFiles((prev) => prev.filter((f) => f.id !== id)), []);
   const clear = useCallback(() => setFiles([]), []);
 
   return { files, addFiles, removeFile, clear };

--- a/hooks/useSpeech.ts
+++ b/hooks/useSpeech.ts
@@ -68,3 +68,4 @@ function useSpeech(opts?: Options): SpeechState {
 
 export default useSpeech;
 export { useSpeech };
+

--- a/hooks/useVoiceOut.ts
+++ b/hooks/useVoiceOut.ts
@@ -1,0 +1,37 @@
+'use client';
+
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+
+export default function useVoiceOut(opts?: { voiceHint?: 'female' | 'male' }) {
+  const synth = useMemo(() => (typeof window !== 'undefined' ? window.speechSynthesis : null), []);
+  const [speakEnabled, setSpeakEnabled] = useState(false);
+  const voicesRef = useRef<SpeechSynthesisVoice[] | null>(null);
+
+  useEffect(() => {
+    if (!synth) return;
+    const load = () => { voicesRef.current = synth.getVoices(); };
+    load();
+    synth.onvoiceschanged = load;
+  }, [synth]);
+
+  const pickVoice = useCallback(() => {
+    const list = voicesRef.current || [];
+    const pref = (opts?.voiceHint === 'male') ? /male|baritone/i : /female|alto|soprano/i;
+    return list.find(v => pref.test(v.name)) || list[0] || null;
+  }, [opts?.voiceHint]);
+
+  const speak = useCallback((text: string) => {
+    if (!synth || !speakEnabled || !text) return;
+    synth.cancel();
+    const u = new SpeechSynthesisUtterance(text);
+    const v = pickVoice();
+    if (v) u.voice = v;
+    u.rate = 1.0; u.pitch = 1.0; u.lang = 'en-US';
+    synth.speak(u);
+  }, [synth, speakEnabled, pickVoice]);
+
+  const toggleSpeak = useCallback(() => setSpeakEnabled((s) => !s), []);
+
+  return { speakEnabled, toggleSpeak, speak };
+}
+


### PR DESCRIPTION
## Summary
- implement Via chat page with image analysis callouts, voice input/output, and attachment support
- add Via-themed styles and chips
- add hooks for file upload and voice output

## Testing
- `npm run lint`
- `npm run typecheck`
- `npm test` *(fails: browserType.launch: Executable doesn't exist at /root/.cache/ms-playwright/...)*

------
https://chatgpt.com/codex/tasks/task_e_689ebb3b6348832292dec3f02f27d637