### PR TITLE
fix: lazily init OpenAI client to avoid build crash

### DIFF
--- a/app/api/ai/explain/route.ts
+++ b/app/api/ai/explain/route.ts
@@ -1,6 +1,7 @@
-export const runtime = 'nodejs'
-
 import { NextResponse } from 'next/server'
+
+export const runtime = 'nodejs'
+export const dynamic = 'force-dynamic'
 
 export async function POST(req: Request) {
   const { questionText, answers } = await req.json()

--- a/app/api/realtime/offer/route.ts
+++ b/app/api/realtime/offer/route.ts
@@ -1,4 +1,5 @@
 export const runtime = 'nodejs'
+export const dynamic = 'force-dynamic'
 
 export async function POST(req: Request) {
   // IMPORTANT: Use the EPHEMERAL client secret from the browser, not the server key.

--- a/app/api/realtime/session/route.ts
+++ b/app/api/realtime/session/route.ts
@@ -1,4 +1,5 @@
 export const runtime = 'nodejs'
+export const dynamic = 'force-dynamic'
 
 export async function POST() {
   const apiKey = process.env.OPENAI_API_KEY

--- a/app/api/via/answer/route.ts
+++ b/app/api/via/answer/route.ts
@@ -1,31 +1,39 @@
-export const runtime = 'nodejs'
-import OpenAI from 'openai'
 import { NextResponse } from 'next/server'
+import { getOpenAI } from '@/lib/openai'
 
-const client = new OpenAI({ apiKey: process.env.OPENAI_API_KEY })
+export const runtime = 'nodejs'
+export const dynamic = 'force-dynamic'
 
 export async function POST(req: Request) {
-  const { question, context } = await req.json().catch(() => ({}))
-  if (!question) return NextResponse.json({ error: 'MISSING_QUESTION' }, { status: 400 })
+  try {
+    const { question, context } = await req.json().catch(() => ({}))
+    if (!question) return NextResponse.json({ error: 'MISSING_QUESTION' }, { status: 400 })
 
-  const schema = {
-    type: 'object',
-    properties: {
-      answer: { type: 'string' },
-      actions: { type: 'array', items: { type: 'string' } }, // e.g., ["suggest_trim", "check_contrast"]
-    },
-    required: ['answer'],
-    additionalProperties: false,
+    const schema = {
+      type: 'object',
+      properties: {
+        answer: { type: 'string' },
+        actions: { type: 'array', items: { type: 'string' } }, // e.g., ["suggest_trim", "check_contrast"]
+      },
+      required: ['answer'],
+      additionalProperties: false,
+    }
+
+    const openai = getOpenAI()
+    const resp = await openai.responses.create({
+      model: 'gpt-5-mini',
+      input: [
+        { role: 'system', content: 'You are Via, an interior paint specialist. Be precise and actionable.' },
+        { role: 'user', content: JSON.stringify({ question, context }) },
+      ],
+      response_format: { type: 'json_schema', json_schema: { name: 'ViaAnswer', schema } } as any,
+    } as any)
+
+    return NextResponse.json(JSON.parse(resp.output_text || '{"answer":""}'))
+  } catch (err: any) {
+    return NextResponse.json(
+      { error: err?.message ?? 'Internal error' },
+      { status: 500 }
+    )
   }
-
-  const resp = await client.responses.create({
-    model: 'gpt-5-mini',
-    input: [
-      { role: 'system', content: 'You are Via, an interior paint specialist. Be precise and actionable.' },
-      { role: 'user', content: JSON.stringify({ question, context }) },
-    ],
-    response_format: { type: 'json_schema', json_schema: { name: 'ViaAnswer', schema } } as any,
-  } as any)
-
-  return NextResponse.json(JSON.parse(resp.output_text || '{"answer":""}'))
 }

--- a/app/api/vision/analyze/route.ts
+++ b/app/api/vision/analyze/route.ts
@@ -1,16 +1,16 @@
-import OpenAI from "openai";
 import { NextRequest } from "next/server";
 import { VISION_MODEL } from "@/lib/ai/config";
+import { getOpenAI } from "@/lib/openai";
 
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
 export async function POST(req: NextRequest) {
   try {
     const { imageUrl } = await req.json();
     if (!imageUrl) return new Response(JSON.stringify({ error: "imageUrl required" }), { status: 400 });
 
-    const apiKey = process.env.OPENAI_API_KEY;
-    if (!apiKey) return new Response(JSON.stringify({ error: "missing OpenAI API key" }), { status: 500 });
-    const client = new OpenAI({ apiKey });
-    const res = await client.responses.create({
+    const openai = getOpenAI();
+    const res = await openai.responses.create({
       model: VISION_MODEL,
       input: [
         { role: "user", content: [

--- a/lib/ai/narrative.ts
+++ b/lib/ai/narrative.ts
@@ -1,6 +1,7 @@
 import { getDesigner } from '@/lib/ai/designers'
 import { AI_ENABLE, AI_MODEL, AI_MAX_OUTPUT_TOKENS, HAS_OPENAI_KEY } from '@/lib/ai/config'
 import { capture, enabled as analyticsEnabled } from '@/lib/analytics/server'
+import { getOpenAI } from '@/lib/openai'
 
 type LegacySwatch = { role: string; brand: string; code: string; name: string; hex: string }
 
@@ -45,9 +46,8 @@ export async function polishWithLLM(text: string, designerId?: string) {
   const d = getDesigner(designerId || '')
   const system = `${d?.style || ''}\nConstraints: 2–3 short sentences, warm and specific. Keep facts.`
   try {
-    const { OpenAI } = await import('openai')
-    const client = new OpenAI({ apiKey: process.env.OPENAI_API_KEY })
-    const resp = await client.chat.completions.create({
+    const openai = getOpenAI()
+    const resp = await openai.chat.completions.create({
       model: AI_MODEL,
       temperature: 0.3,
       max_tokens: Math.min(120, AI_MAX_OUTPUT_TOKENS),

--- a/lib/ai/orchestrator.ts
+++ b/lib/ai/orchestrator.ts
@@ -5,6 +5,7 @@ import { byBrand, isNearWhite, isNeutral, contrastScore, excludeByAvoid } from '
 import { makeRNG, pick } from '@/lib/utils/seededRandom'
 import { capture, enabled as analyticsEnabled } from '@/lib/analytics/server'
 import { AI_ENABLE, AI_MODEL, AI_MAX_OUTPUT_TOKENS, HAS_OPENAI_KEY } from '@/lib/ai/config'
+import { getOpenAI } from '@/lib/openai'
 
 type Candidates = { neutrals: Color[]; whites: Color[]; accents: Color[] }
 
@@ -83,14 +84,12 @@ function sanitizeLlmPalette(parsed: Palette | null, candidates: Candidates, fall
 
 async function tryLlmPick(input: DesignInput, candidates: Candidates, fallback: Palette): Promise<Palette | null> {
   if (!AI_ENABLE || !HAS_OPENAI_KEY) return null
-  let OpenAIImpl: any
+  let client: ReturnType<typeof getOpenAI>
   try {
-    const mod = await import('openai')
-    OpenAIImpl = (mod as any).OpenAI
+    client = getOpenAI()
   } catch {
     return null
   }
-  const client = new OpenAIImpl({ apiKey: process.env.OPENAI_API_KEY })
   const payload = {
     input,
     candidates: {

--- a/lib/openai.ts
+++ b/lib/openai.ts
@@ -1,0 +1,14 @@
+import OpenAI from "openai";
+
+let _client: OpenAI | null = null;
+
+export function getOpenAI(): OpenAI {
+  if (_client) return _client;
+  const apiKey = process.env.OPENAI_API_KEY;
+  if (!apiKey) {
+    // Throw only when a route is actually invoked, not at module import time
+    throw new Error("Server misconfigured: OPENAI_API_KEY is missing.");
+  }
+  _client = new OpenAI({ apiKey });
+  return _client;
+}

--- a/next.config.js
+++ b/next.config.js
@@ -35,6 +35,13 @@ const nextConfig = {
         ]
       }
     ];
+  },
+  webpack: (config) => {
+    config.ignoreWarnings = [
+      /Critical dependency: the request of a dependency is an expression/,
+      /require function is used in a way in which dependencies cannot be statically extracted/,
+    ];
+    return config;
   }
 };
 


### PR DESCRIPTION
## Summary
- lazy initialize OpenAI client via shared helper
- force Node runtime/dynamic for OpenAI API routes
- silence noisy webpack warnings

## Testing
- `npm test` *(fails: browserType.launch: Executable doesn't exist at /root/.cache/ms-playwright/...)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689ec3705a688322aaff449438010f02