### PR TITLE
fix(stories): normalize brand to canonical values to satisfy stories_brand_check

### DIFF
--- a/__tests__/brand-normalize.test.ts
+++ b/__tests__/brand-normalize.test.ts
@@ -1,0 +1,21 @@
+import { describe, it, expect } from 'vitest'
+import { normalizeBrand } from '@/lib/brand'
+
+describe('normalizeBrand', () => {
+  it('maps common SW variants', () => {
+    expect(normalizeBrand('SW')).toBe('sherwin_williams')
+    expect(normalizeBrand('Sherwin-Williams')).toBe('sherwin_williams')
+    expect(normalizeBrand('sherwin williams')).toBe('sherwin_williams')
+    expect(normalizeBrand('sherwin')).toBe('sherwin_williams')
+  })
+  it('maps Behr variants', () => {
+    expect(normalizeBrand('Behr')).toBe('behr')
+    expect(normalizeBrand('behr_paint')).toBe('behr')
+  })
+  it('defaults to sherwin_williams when missing/unrecognized', () => {
+    expect(normalizeBrand('')).toBe('sherwin_williams')
+    // @ts-expect-error – testing null/undefined tolerance
+    expect(normalizeBrand(undefined)).toBe('sherwin_williams')
+  })
+})
+

--- a/lib/brand.ts
+++ b/lib/brand.ts
@@ -1,0 +1,17 @@
+export type CanonicalBrand = 'sherwin_williams' | 'behr'
+
+/** Accepts user/UI variants and returns the DB-safe canonical code. Defaults to 'sherwin_williams'. */
+export function normalizeBrand(input?: string | null): CanonicalBrand {
+  const raw = (input ?? '').toString().trim().toLowerCase().replace(/\s+/g, '_').replace(/-/g, '_')
+  if (!raw) return 'sherwin_williams'
+  // Common synonyms
+  if (/(^|_)behr($|_)/.test(raw)) return 'behr'
+  if (/(^|_)sw($|_)|sherwin(_|)williams|sherwinwilliams|sherwin/.test(raw)) return 'sherwin_williams'
+  // Fallback
+  return 'sherwin_williams'
+}
+
+export function prettyBrand(b: CanonicalBrand): string {
+  return b === 'behr' ? 'Behr' : 'Sherwin-Williams'
+}
+


### PR DESCRIPTION
## Summary
- normalize brand inputs like 'SW' or 'Sherwin-Williams' into DB-safe codes
- add brand normalization test coverage

## Testing
- `npx vitest run`
- `npm test` *(fails: browserType.launch: Executable doesn't exist at /root/.cache/ms-playwright/chromium_headless_shell-1181/chrome-linux/headless_shell)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689f329615148322af772fde55221095