### PR TITLE
Pass full design inputs to palette builder

### DIFF
--- a/__tests__/brand-normalize.test.ts
+++ b/__tests__/brand-normalize.test.ts
@@ -14,8 +14,7 @@ describe('normalizeBrand', () => {
   })
   it('defaults to sherwin_williams when missing/unrecognized', () => {
     expect(normalizeBrand('')).toBe('sherwin_williams')
-    // @ts-expect-error – testing null/undefined tolerance
-    expect(normalizeBrand(undefined)).toBe('sherwin_williams')
+    expect(normalizeBrand(undefined as any)).toBe('sherwin_williams')
   })
 })
 

--- a/app/api/stories/route.ts
+++ b/app/api/stories/route.ts
@@ -112,8 +112,8 @@ export async function POST(req: Request) {
       }
     }
 
-    // 2. Build a new palette with the AI orchestrator, then normalize/repair
-    const generated = await designPalette({ brand: brandCanonical, vibe: vibeSafe } as DesignInput)
+    // 2. Build a new palette with the AI orchestrator using full inputs, then normalize/repair
+    const generated = await designPalette({ ...inputs, brand: brandCanonical, vibe: vibeSafe } as DesignInput)
     const legacy = mapV2ToLegacy(generated as V2Palette)
     let finalPalette: any
     const testEnv =


### PR DESCRIPTION
## Summary
- pass entire `inputs` object to `designPalette` in stories API
- derive seeds from all interview answers so each session has unique seed
- adjust brand normalization test for typecheck

## Testing
- `npx vitest run` *(fails: Playwright tests and others)*
- `npm test` *(fails: missing Playwright browsers)*
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_689f3e7396b083228ec4a24dcf2ea2ca