### PR TITLE
feat(interview): add /api/interview router for realtime vs form; surface models on status

### DIFF
--- a/app/api/ai/status/route.ts
+++ b/app/api/ai/status/route.ts
@@ -1,6 +1,6 @@
 export const runtime = 'nodejs'
 import { NextResponse } from 'next/server'
-import { AI_ENABLE, AI_MODEL, HAS_OPENAI_KEY, VIA_CHAT_MODEL, VIA_CHAT_FAST_MODEL, VIA_INTERVIEW_MODEL, PALETTE_MODEL } from '@/lib/ai/config'
+import { AI_ENABLE, AI_MODEL, HAS_OPENAI_KEY, VIA_CHAT_MODEL, VIA_CHAT_FAST_MODEL, VIA_INTERVIEW_MODEL, PALETTE_MODEL, REALTIME_MODEL } from '@/lib/ai/config'
 
 export async function GET() {
   return NextResponse.json({
@@ -12,6 +12,11 @@ export async function GET() {
       chatFastModel: VIA_CHAT_FAST_MODEL,
       interviewModel: VIA_INTERVIEW_MODEL,
       paletteModel: PALETTE_MODEL
+    },
+    interview: {
+      modes: ['realtime', 'form'],
+      realtime: { model: REALTIME_MODEL, session: '/api/realtime/session', offer: '/api/realtime/offer' },
+      form: { model: VIA_INTERVIEW_MODEL, endpoint: '/api/interview' }
     },
     hasKey: HAS_OPENAI_KEY
   })

--- a/app/api/interview/route.ts
+++ b/app/api/interview/route.ts
@@ -1,0 +1,71 @@
+export const runtime = 'nodejs'
+export const dynamic = 'force-dynamic'
+
+import { NextResponse } from 'next/server'
+import { VIA_INTERVIEW_MODEL, REALTIME_MODEL, AI_MAX_OUTPUT_TOKENS } from '@/lib/ai/config'
+import { getOpenAI } from '@/lib/openai'
+
+type Mode = 'realtime' | 'form'
+
+type Body = {
+  mode?: Mode
+  // For form mode:
+  questionText?: string
+  answers?: Record<string, any>
+}
+
+/**
+ * POST /api/interview
+ * body: { mode: 'realtime' } OR { mode: 'form', questionText, answers }
+ *
+ * - realtime: returns endpoints + model for the existing WebRTC Realtime flow
+ * - form: runs the explainer using VIA_INTERVIEW_MODEL
+ */
+export async function POST(req: Request) {
+  const body = (await req.json().catch(() => ({}))) as Body
+  const mode: Mode = (body.mode === 'realtime' ? 'realtime' : 'form')
+
+  if (mode === 'realtime') {
+    // We already have Realtime endpoints:
+    //   /api/realtime/session → gets an EPHEMERAL client secret (browser uses this)
+    //   /api/realtime/offer   → forwards the SDP to OpenAI
+    return NextResponse.json({
+      mode,
+      model: REALTIME_MODEL,
+      sessionEndpoint: '/api/realtime/session',
+      offerEndpoint: '/api/realtime/offer'
+    })
+  }
+
+  // Default: text form helper (explanation/clarification)
+  const questionText = body.questionText || ''
+  const answers = body.answers || {}
+
+  const prompt = `Explain this interview question to a homeowner in 2-4 friendly sentences.
+Question: "${questionText}"
+Context (prior answers): ${JSON.stringify(answers ?? {}, null, 0)}
+Keep it non-technical and give a quick example if helpful.`
+
+  try {
+    const client = getOpenAI()
+    const r = await client.chat.completions.create({
+      model: VIA_INTERVIEW_MODEL,
+      messages: [
+        { role: 'system', content: 'You are a friendly interior design assistant.' },
+        { role: 'user', content: prompt }
+      ],
+      temperature: 0.3,
+      max_tokens: AI_MAX_OUTPUT_TOKENS
+    })
+    const explanation = r?.choices?.[0]?.message?.content?.trim() || defaultExplain(questionText)
+    return NextResponse.json({ mode, model: VIA_INTERVIEW_MODEL, explanation })
+  } catch (e: any) {
+    console.error('[interview][form] error', e?.message || e)
+    return NextResponse.json({ mode, model: VIA_INTERVIEW_MODEL, explanation: defaultExplain(questionText), fallback: true })
+  }
+}
+
+function defaultExplain(questionText: string) {
+  return `We ask “${questionText}” so your palette fits real-life use. A short answer in your own words is perfect; pick a suggested option if it fits.`
+}
+

--- a/docs/ENVIRONMENT.md
+++ b/docs/ENVIRONMENT.md
@@ -17,3 +17,12 @@ Optional:
 - `OPENAI_VISION_MODEL`, `OPENAI_REALTIME_MODEL`, etc.
 
 > Never paste secrets in chat. Store them only in Vercel envs.
+
+## Interview Routing
+
+- `POST /api/interview` with `{ "mode": "realtime" }` → returns `{ sessionEndpoint, offerEndpoint, model }`.
+- `POST /api/interview` with `{ "mode": "form", "questionText": "...", "answers": { ... } }` → returns `{ explanation, model }`.
+
+### Envs
+- `OPENAI_REALTIME_MODEL` (default: `gpt-4o-mini`) – used for live talk.
+- `VIA_INTERVIEW_MODEL` (default: `gpt-5-mini`) – used for text form explains.


### PR DESCRIPTION
## Summary
- add /api/interview endpoint to route interview flows to realtime or text form helpers
- expose interview modes and models on /api/ai/status
- document interview routing envs in ENVIRONMENT.md

## Testing
- `npm test` (fails: net::ERR_CONNECTION_REFUSED)
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689f6add9adc8322bf57528c22886a15