### PR TITLE
feat(via): add chat tool-calling for undertone analysis and paint facts

### DIFF
--- a/app/api/via/chat/route.ts
+++ b/app/api/via/chat/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from 'next/server'
 import { getOpenAI } from '@/lib/openai'
 import { VIA_CHAT_MODEL, VIA_CHAT_FAST_MODEL, AI_MAX_OUTPUT_TOKENS } from '@/lib/ai/config'
+import { viaTools } from '@/lib/via/tools'
 
 export const runtime = 'nodejs'
 // Chat is live/user-specific; avoid build-time client creation.
@@ -19,14 +20,84 @@ export async function POST(req: Request) {
   const model = fast ? VIA_CHAT_FAST_MODEL : VIA_CHAT_MODEL
   try {
     const client = getOpenAI()
-    const r = await client.chat.completions.create({
-      model,
-      messages,
-      temperature: 0.2,
-      max_tokens: AI_MAX_OUTPUT_TOKENS
-    })
-    const reply = r?.choices?.[0]?.message?.content ?? ''
-    return NextResponse.json({ reply, model })
+    // 1) Ask the model, offering tools it can call when needed
+    let toolMessages: any[] = []
+    let step = 0
+    while (step < 3) {
+      step++
+      const r = await client.chat.completions.create({
+        model,
+        temperature: 0.2,
+        max_tokens: AI_MAX_OUTPUT_TOKENS,
+        tools: [
+          {
+            type: 'function',
+            function: {
+              name: 'analyzeImageForUndertones',
+              description: 'Analyze an image URL to estimate undertones and dominant swatches.',
+              parameters: {
+                type: 'object',
+                properties: { url: { type: 'string', description: 'Publicly accessible image URL' } },
+                required: ['url']
+              }
+            }
+          },
+          {
+            type: 'function',
+            function: {
+              name: 'getPaintFacts',
+              description: 'Look up paint facts (brand, code, undertone, notes) by name or code.',
+              parameters: {
+                type: 'object',
+                properties: { query: { type: 'string', description: 'E.g., "Alabaster" or "SW 7008"' } },
+                required: ['query']
+              }
+            }
+          }
+        ],
+        messages: [
+          {
+            role: 'system',
+            content:
+              'You are Via, a friendly paint expert. Use tools when asked about undertones in a specific photo or brand-specific facts. If a user mentions a photo but no image is provided, ask for an image upload first.'
+          },
+          ...messages,
+          ...toolMessages
+        ]
+      })
+      const choice = r.choices?.[0]
+      const msg: any = choice?.message
+      // If the model wants to call a tool, handle it then continue
+      const calls = msg?.tool_calls
+      if (Array.isArray(calls) && calls.length) {
+        for (const call of calls) {
+          const { name, arguments: argsStr } = call.function || {}
+          let result: any = { error: 'unknown_tool' }
+          try {
+            const args = argsStr ? JSON.parse(argsStr) : {}
+            if (name === 'analyzeImageForUndertones') {
+              result = await viaTools.analyzeImageForUndertones(args.url)
+            } else if (name === 'getPaintFacts') {
+              result = await viaTools.getPaintFacts(args.query)
+            }
+          } catch (e:any) {
+            result = { error: String(e?.message || e) }
+          }
+          toolMessages.push({
+            role: 'tool',
+            tool_call_id: call.id,
+            name,
+            content: JSON.stringify(result)
+          })
+        }
+        continue
+      }
+      // No tool calls → return the answer
+      const reply = msg?.content ?? ''
+      return NextResponse.json({ reply, model })
+    }
+    // Fallback
+    return NextResponse.json({ reply: 'Sorry—try rephrasing that question.', model })
   } catch (e: any) {
     return NextResponse.json({ error: 'chat_failed', detail: String(e?.message || e) }, { status: 500 })
   }

--- a/docs/ENVIRONMENT.md
+++ b/docs/ENVIRONMENT.md
@@ -26,3 +26,12 @@ Optional:
 ### Envs
 - `OPENAI_REALTIME_MODEL` (default: `gpt-4o-mini`) – used for live talk.
 - `VIA_INTERVIEW_MODEL` (default: `gpt-5-mini`) – used for text form explains.
+
+## Via Tools
+
+- `analyzeImageForUndertones(url)` uses **sharp** to downsample and infer undertones.
+- `getPaintFacts(query)` reads from Supabase `paint_colors` (name, brand, code, hex, undertone, notes).
+
+Envs needed for paint facts:
+- `NEXT_PUBLIC_SUPABASE_URL`
+- `SUPABASE_SERVICE_ROLE_KEY`

--- a/lib/via/tools.ts
+++ b/lib/via/tools.ts
@@ -1,0 +1,100 @@
+import sharp from 'sharp'
+import { createClient } from '@supabase/supabase-js'
+
+export type UndertoneResult = {
+  undertone: 'warm' | 'cool' | 'neutral' | 'mixed'
+  confidence: number
+  swatches: { hex: string; percent: number }[]
+  notes?: string
+}
+
+export const viaTools = {
+  // Tool 1: Analyze image for undertones (fast heuristic; good enough for chat)
+  async analyzeImageForUndertones(url: string): Promise<UndertoneResult> {
+    if (!url) throw new Error('image url required')
+    // Fetch the image
+    const res = await fetch(url)
+    if (!res.ok) throw new Error(`image fetch failed: ${res.status}`)
+    const buf = Buffer.from(await res.arrayBuffer())
+    // Downsample and get raw pixels
+    const { data, info } = await sharp(buf).resize(64, 64, { fit: 'inside' }).removeAlpha().raw().toBuffer({ resolveWithObject: true })
+    const total = info.width * info.height
+    // Simple quantization: bucket RGB to 16 steps/channel to build a palette
+    const buckets = new Map<string, number>()
+    let warm = 0, cool = 0, neutral = 0
+    for (let i = 0; i < data.length; i += 3) {
+      const r = data[i], g = data[i + 1], b = data[i + 2]
+      // HSL conversion
+      const [h, s, l] = rgbToHsl(r, g, b)
+      // Undertone buckets
+      if (s < 0.18 && l > 0.35 && l < 0.95) {
+        neutral++
+        // light red tilt counts as warm; blue tilt as cool
+        if (r > b + 10 && r > g + 10) warm++
+        else if (b > r + 10 && b > g + 10) cool++
+      } else {
+        if (h >= 20 && h <= 70) warm++ // yellow–warm reds
+        else if (h >= 180 && h <= 260) cool++ // cyan–blue
+      }
+      // Palette bucketing
+      const R = Math.round(r / 16) * 16
+      const G = Math.round(g / 16) * 16
+      const B = Math.round(b / 16) * 16
+      const key = `${R},${G},${B}`
+      buckets.set(key, (buckets.get(key) || 0) + 1)
+    }
+    const warmPct = warm / total, coolPct = cool / total, neutralPct = neutral / total
+    const maxPct = Math.max(warmPct, coolPct, neutralPct)
+    const undertone = maxPct < 0.4 ? 'mixed' : (maxPct === warmPct ? 'warm' : maxPct === coolPct ? 'cool' : 'neutral')
+    // Top 3 swatches
+    const top = [...buckets.entries()].sort((a,b)=>b[1]-a[1]).slice(0, 3).map(([k,count])=>{
+      const [R,G,B] = k.split(',').map(Number)
+      return { hex: rgbToHex(R,G,B), percent: count/total }
+    })
+    return {
+      undertone,
+      confidence: clamp01(maxPct),
+      swatches: top,
+      notes: 'Heuristic analysis; lighting/white balance can affect perceived undertones.'
+    }
+  },
+
+  // Tool 2: Paint facts lookup (Supabase). Query by name, code, or brand.
+  async getPaintFacts(query: string) {
+    if (!query) throw new Error('query required')
+    const url = process.env.NEXT_PUBLIC_SUPABASE_URL
+    const key = process.env.SUPABASE_SERVICE_ROLE_KEY
+    if (!url || !key) return { results: [], warning: 'Supabase envs missing; returning empty results.' }
+    const supabase = createClient(url, key, { auth: { persistSession:false }, db: { schema: 'public' } })
+    // Example table schema: paint_colors(name, brand, code, hex, lab_l, lab_a, lab_b, undertone, notes)
+    const { data, error } = await supabase
+      .from('paint_colors')
+      .select('name,brand,code,hex,undertone,notes')
+      .ilike('name', `%${query}%`)
+      .limit(5)
+    if (error) return { results: [], warning: error.message }
+    return { results: data || [] }
+  }
+}
+
+// ---------- small helpers ----------
+function rgbToHex(r:number,g:number,b:number) {
+  return '#' + [r,g,b].map(x=>x.toString(16).padStart(2,'0')).join('')
+}
+function rgbToHsl(r:number,g:number,b:number): [number, number, number] {
+  r/=255; g/=255; b/=255
+  const max=Math.max(r,g,b), min=Math.min(r,g,b)
+  let h=0,s=0; const l=(max+min)/2
+  if(max!==min){
+    const d=max-min
+    s=l>0.5 ? d/(2-max-min) : d/(max+min)
+    switch(max){
+      case r: h=(g-b)/d+(g<b?6:0); break
+      case g: h=(b-r)/d+2; break
+      case b: h=(r-g)/d+4; break
+    }
+    h/=6
+  }
+  return [Math.round(h*360), s, l]
+}
+function clamp01(x:number){ return Math.max(0, Math.min(1, x)) }

--- a/package-lock.json
+++ b/package-lock.json
@@ -30,6 +30,7 @@
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
         "react-hook-form": "7.49.2",
+        "sharp": "^0.33.4",
         "stripe": "latest",
         "tailwind-merge": "2.2.1",
         "zod": "3.23.8"
@@ -516,7 +517,6 @@
       "version": "1.4.5",
       "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.4.5.tgz",
       "integrity": "sha512-++LApOtY0pEEz1zrd9vy1/zXVaVJJ/EbAF3u0fXIzPJEDtnITsBGbbK0EkM72amhl/R5b+5xx0Y/QhcVOpuulg==",
-      "dev": true,
       "optional": true,
       "dependencies": {
         "tslib": "^2.4.0"
@@ -1124,6 +1124,367 @@
       "integrity": "sha512-93zYdMES/c1D69yZiKDBj0V24vqNzB/koF26KPaagAfd3P/4gUlh3Dys5ogAK+Exi9QyzlD8x/08Zt7wIKcDcA==",
       "deprecated": "Use @eslint/object-schema instead",
       "dev": true
+    },
+    "node_modules/@img/sharp-darwin-arm64": {
+      "version": "0.33.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-arm64/-/sharp-darwin-arm64-0.33.5.tgz",
+      "integrity": "sha512-UT4p+iz/2H4twwAoLCqfA9UH5pI6DggwKEGuaPy7nCVQ8ZsiY5PIcrRvD1DzuY3qYL07NtIQcWnBSY/heikIFQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-darwin-arm64": "1.0.4"
+      }
+    },
+    "node_modules/@img/sharp-darwin-x64": {
+      "version": "0.33.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-x64/-/sharp-darwin-x64-0.33.5.tgz",
+      "integrity": "sha512-fyHac4jIc1ANYGRDxtiqelIbdWkIuQaI84Mv45KvGRRxSAa7o7d1ZKAOBaYbnepLC1WqxfpimdeWfvqqSGwR2Q==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-darwin-x64": "1.0.4"
+      }
+    },
+    "node_modules/@img/sharp-libvips-darwin-arm64": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-arm64/-/sharp-libvips-darwin-arm64-1.0.4.tgz",
+      "integrity": "sha512-XblONe153h0O2zuFfTAbQYAX2JhYmDHeWikp1LM9Hul9gVPjFY427k6dFEcOL72O01QxQsWi761svJ/ev9xEDg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-darwin-x64": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-x64/-/sharp-libvips-darwin-x64-1.0.4.tgz",
+      "integrity": "sha512-xnGR8YuZYfJGmWPvmlunFaWJsb9T/AO2ykoP3Fz/0X5XV2aoYBPkX6xqCQvUTKKiLddarLaxpzNe+b1hjeWHAQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-arm": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm/-/sharp-libvips-linux-arm-1.0.5.tgz",
+      "integrity": "sha512-gvcC4ACAOPRNATg/ov8/MnbxFDJqf/pDePbBnuBDcjsI8PssmjoKMAz4LtLaVi+OnSb5FK/yIOamqDwGmXW32g==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-arm64": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm64/-/sharp-libvips-linux-arm64-1.0.4.tgz",
+      "integrity": "sha512-9B+taZ8DlyyqzZQnoeIvDVR/2F4EbMepXMc/NdVbkzsJbzkUjhXv/70GQJ7tdLA4YJgNP25zukcxpX2/SueNrA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-s390x": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-s390x/-/sharp-libvips-linux-s390x-1.0.4.tgz",
+      "integrity": "sha512-u7Wz6ntiSSgGSGcjZ55im6uvTrOxSIS8/dgoVMoiGE9I6JAfU50yH5BoDlYA1tcuGS7g/QNtetJnxA6QEsCVTA==",
+      "cpu": [
+        "s390x"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-x64": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-x64/-/sharp-libvips-linux-x64-1.0.4.tgz",
+      "integrity": "sha512-MmWmQ3iPFZr0Iev+BAgVMb3ZyC4KeFc3jFxnNbEPas60e1cIfevbtuyf9nDGIzOaW9PdnDciJm+wFFaTlj5xYw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linuxmusl-arm64": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-arm64/-/sharp-libvips-linuxmusl-arm64-1.0.4.tgz",
+      "integrity": "sha512-9Ti+BbTYDcsbp4wfYib8Ctm1ilkugkA/uscUn6UXK1ldpC1JjiXbLfFZtRlBhjPZ5o1NCLiDbg8fhUPKStHoTA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linuxmusl-x64": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-x64/-/sharp-libvips-linuxmusl-x64-1.0.4.tgz",
+      "integrity": "sha512-viYN1KX9m+/hGkJtvYYp+CCLgnJXwiQB39damAO7WMdKWlIhmYTfHjwSbQeUK/20vY154mwezd9HflVFM1wVSw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-linux-arm": {
+      "version": "0.33.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm/-/sharp-linux-arm-0.33.5.tgz",
+      "integrity": "sha512-JTS1eldqZbJxjvKaAkxhZmBqPRGmxgu+qFKSInv8moZ2AmT5Yib3EQ1c6gp493HvrvV8QgdOXdyaIBrhvFhBMQ==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-arm": "1.0.5"
+      }
+    },
+    "node_modules/@img/sharp-linux-arm64": {
+      "version": "0.33.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm64/-/sharp-linux-arm64-0.33.5.tgz",
+      "integrity": "sha512-JMVv+AMRyGOHtO1RFBiJy/MBsgz0x4AWrT6QoEVVTyh1E39TrCUpTRI7mx9VksGX4awWASxqCYLCV4wBZHAYxA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-arm64": "1.0.4"
+      }
+    },
+    "node_modules/@img/sharp-linux-s390x": {
+      "version": "0.33.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-s390x/-/sharp-linux-s390x-0.33.5.tgz",
+      "integrity": "sha512-y/5PCd+mP4CA/sPDKl2961b+C9d+vPAveS33s6Z3zfASk2j5upL6fXVPZi7ztePZ5CuH+1kW8JtvxgbuXHRa4Q==",
+      "cpu": [
+        "s390x"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-s390x": "1.0.4"
+      }
+    },
+    "node_modules/@img/sharp-linux-x64": {
+      "version": "0.33.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-x64/-/sharp-linux-x64-0.33.5.tgz",
+      "integrity": "sha512-opC+Ok5pRNAzuvq1AG0ar+1owsu842/Ab+4qvU879ippJBHvyY5n2mxF1izXqkPYlGuP/M556uh53jRLJmzTWA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-x64": "1.0.4"
+      }
+    },
+    "node_modules/@img/sharp-linuxmusl-arm64": {
+      "version": "0.33.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-arm64/-/sharp-linuxmusl-arm64-0.33.5.tgz",
+      "integrity": "sha512-XrHMZwGQGvJg2V/oRSUfSAfjfPxO+4DkiRh6p2AFjLQztWUuY/o8Mq0eMQVIY7HJ1CDQUJlxGGZRw1a5bqmd1g==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linuxmusl-arm64": "1.0.4"
+      }
+    },
+    "node_modules/@img/sharp-linuxmusl-x64": {
+      "version": "0.33.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-x64/-/sharp-linuxmusl-x64-0.33.5.tgz",
+      "integrity": "sha512-WT+d/cgqKkkKySYmqoZ8y3pxx7lx9vVejxW/W4DOFMYVSkErR+w7mf2u8m/y4+xHe7yY9DAXQMWQhpnMuFfScw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linuxmusl-x64": "1.0.4"
+      }
+    },
+    "node_modules/@img/sharp-wasm32": {
+      "version": "0.33.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-wasm32/-/sharp-wasm32-0.33.5.tgz",
+      "integrity": "sha512-ykUW4LVGaMcU9lu9thv85CbRMAwfeadCJHRsg2GmeRa/cJxsVY9Rbd57JcMxBkKHag5U/x7TSBpScF4U8ElVzg==",
+      "cpu": [
+        "wasm32"
+      ],
+      "license": "Apache-2.0 AND LGPL-3.0-or-later AND MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/runtime": "^1.2.0"
+      },
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-win32-ia32": {
+      "version": "0.33.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-ia32/-/sharp-win32-ia32-0.33.5.tgz",
+      "integrity": "sha512-T36PblLaTwuVJ/zw/LaH0PdZkRz5rd3SmMHX8GSmR7vtNSP5Z6bQkExdSK7xGWyxLw4sUknBuugTelgw2faBbQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "license": "Apache-2.0 AND LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-win32-x64": {
+      "version": "0.33.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-x64/-/sharp-win32-x64-0.33.5.tgz",
+      "integrity": "sha512-MpY/o8/8kj+EcnxwvrP4aTJSWw/aZ7JIGR4aBeZkZw5B7/Jn+tY9/VNwtcoGmdT7GfggGIU4kygOMSbYnOrAbg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0 AND LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
     },
     "node_modules/@isaacs/cliui": {
       "version": "8.0.2",
@@ -5683,6 +6044,19 @@
         "node": ">=6"
       }
     },
+    "node_modules/color": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/color/-/color-4.2.3.tgz",
+      "integrity": "sha512-1rXeuUUiGGrykh+CeBdu5Ie7OJwinCgQY0bc7GCRxy5xVHy+moaqkpL/jqQq0MtQOeYcrqEz4abc5f0KtU7W4A==",
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1",
+        "color-string": "^1.9.0"
+      },
+      "engines": {
+        "node": ">=12.5.0"
+      }
+    },
     "node_modules/color-convert": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
@@ -6015,7 +6389,6 @@
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.0.4.tgz",
       "integrity": "sha512-3UDv+G9CsCKO1WKMGw9fwq/SWJYbI0c5Y7LU1AXYoDdbhE2AHQ6N6Nb34sG8Fj7T5APy8qXDCKuuIHd1BR0tVA==",
-      "dev": true,
       "engines": {
         "node": ">=8"
       }
@@ -10561,6 +10934,45 @@
       "resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
       "integrity": "sha512-MATJdZp8sLqDl/68LfQmbP8zKPLQNV6BIZoIgrscFDQ+RsvK/BxeDQOgyxKKoh0y/8h3BqVFnCqQ/gd+reiIXA==",
       "license": "MIT"
+    },
+    "node_modules/sharp": {
+      "version": "0.33.5",
+      "resolved": "https://registry.npmjs.org/sharp/-/sharp-0.33.5.tgz",
+      "integrity": "sha512-haPVm1EkS9pgvHrQ/F3Xy+hgcuMV0Wm9vfIBSiwZ05k+xgb0PkBQpGsAA/oWdDobNaZTH5ppvHtzCFbnSEwHVw==",
+      "hasInstallScript": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "color": "^4.2.3",
+        "detect-libc": "^2.0.3",
+        "semver": "^7.6.3"
+      },
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-darwin-arm64": "0.33.5",
+        "@img/sharp-darwin-x64": "0.33.5",
+        "@img/sharp-libvips-darwin-arm64": "1.0.4",
+        "@img/sharp-libvips-darwin-x64": "1.0.4",
+        "@img/sharp-libvips-linux-arm": "1.0.5",
+        "@img/sharp-libvips-linux-arm64": "1.0.4",
+        "@img/sharp-libvips-linux-s390x": "1.0.4",
+        "@img/sharp-libvips-linux-x64": "1.0.4",
+        "@img/sharp-libvips-linuxmusl-arm64": "1.0.4",
+        "@img/sharp-libvips-linuxmusl-x64": "1.0.4",
+        "@img/sharp-linux-arm": "0.33.5",
+        "@img/sharp-linux-arm64": "0.33.5",
+        "@img/sharp-linux-s390x": "0.33.5",
+        "@img/sharp-linux-x64": "0.33.5",
+        "@img/sharp-linuxmusl-arm64": "0.33.5",
+        "@img/sharp-linuxmusl-x64": "0.33.5",
+        "@img/sharp-wasm32": "0.33.5",
+        "@img/sharp-win32-ia32": "0.33.5",
+        "@img/sharp-win32-x64": "0.33.5"
+      }
     },
     "node_modules/shebang-command": {
       "version": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
     "react-hook-form": "7.49.2",
+    "sharp": "^0.33.4",
     "stripe": "latest",
     "tailwind-merge": "2.2.1",
     "zod": "3.23.8"


### PR DESCRIPTION
## Summary
- add `sharp` dependency and implement `viaTools` with undertone analysis and Supabase paint facts lookup
- update Via chat endpoint to loop with OpenAI tool calling
- document new tools and required env vars

## Testing
- `npm test` *(fails: browserType.launch: Executable doesn't exist; missing system deps even after installing playwright)*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_689f6d92d1308322a7aaa7c2c5693c18