### PR TITLE
fix(via-chat): refine greeting logic and styling

### DIFF
--- a/__tests__/via-greeting-logic.test.ts
+++ b/__tests__/via-greeting-logic.test.ts
@@ -1,0 +1,10 @@
+import { shouldShowGreeting } from '@/app/via/greeting'
+
+describe('Via greeting visibility', () => {
+  it('shows greeting before any messages', () => {
+    expect(shouldShowGreeting(0)).toBe(true)
+  })
+  it('hides greeting after first message', () => {
+    expect(shouldShowGreeting(1)).toBe(false)
+  })
+})

--- a/app/via/greeting.ts
+++ b/app/via/greeting.ts
@@ -1,0 +1,4 @@
+// tiny pure helper so we can unit test the greeting visibility logic
+export function shouldShowGreeting(messageCount: number) {
+  return messageCount === 0
+}

--- a/app/via/page.tsx
+++ b/app/via/page.tsx
@@ -10,6 +10,7 @@ import useSpeech from '@/hooks/useSpeech';
 import useFileUpload from '@/hooks/useFileUpload';
 import useVoiceOut from '@/hooks/useVoiceOut';
 import { cn } from '@/lib/utils';
+import { shouldShowGreeting } from './greeting';
 
 export default function ViaPage() {
   // Conversation
@@ -180,19 +181,33 @@ export default function ViaPage() {
           aria-label="Via chat panel"
         >
           {/* Header */}
-          <header className="p-6 md:p-8 flex items-start justify-between gap-4">
+          <header
+            className={cn(
+              shouldShowGreeting(messages.length) ? 'p-6 md:p-8' : 'p-2 md:p-4',
+              'flex items-start justify-between gap-4'
+            )}
+          >
             <div>
-              <h1 className="font-display text-4xl md:text-5xl leading-tight text-[--via-ink] via-type-in" aria-live="polite">
-                {bootTyped || '‎'}
-              </h1>
-              <p className="mt-3 text-[15px] md:text-base text-[--via-ink-subtle]">how can i help?</p>
-              {showSuggestions && (
-                <div className="mt-5">
-                  <PrefilledButtons
-                    items={['design a palette', 'talk about paint', 'something else']}
-                    onPick={(s) => { setPendingInput(s); sendMessage(s); }}
-                  />
-                </div>
+              {shouldShowGreeting(messages.length) && (
+                <>
+                  <h1
+                    className="font-display text-4xl md:text-5xl leading-tight text-[--via-olive] via-type-in"
+                    aria-live="polite"
+                  >
+                    {bootTyped || '‎'}
+                  </h1>
+                  <p className="mt-3 text-[15px] md:text-base text-[--via-olive]">
+                    how can i help?
+                  </p>
+                  {showSuggestions && (
+                    <div className="mt-5">
+                      <PrefilledButtons
+                        items={['design a palette', 'talk about paint', 'something else']}
+                        onPick={(s) => { setPendingInput(s); sendMessage(s); }}
+                      />
+                    </div>
+                  )}
+                </>
               )}
             </div>
 

--- a/app/via/via.css
+++ b/app/via/via.css
@@ -1,9 +1,10 @@
 /* ---------- Brand-scoped tokens for /via ---------- */
 .theme-via {
-  /* Background: pastel peach → warm white */
-  --via-peach: oklch(0.92 0.05 45);
-  --via-peach-2: oklch(0.99 0.01 95);
-  --via-bg: linear-gradient(180deg, var(--via-peach) 0%, var(--via-peach-2) 52%);
+  /* Background: stronger peach at top → fade to white sooner */
+  --via-peach: oklch(0.88 0.06 45);
+  --via-peach-2: oklch(0.995 0 95);
+  /* push color into the top ~30%, then get to white by ~60% */
+  --via-bg: linear-gradient(180deg, var(--via-peach) 0%, oklch(0.985 0.02 50) 28%, white 60%);
   background: var(--via-bg);
   /* Card surface + text */
   --via-panel: oklch(0.985 0.005 95);
@@ -109,9 +110,13 @@
 
 /* Input */
 .via-input {
-  background: oklch(.99 .004 95);
+  background: white; /* white surface for maximum contrast */
   border-radius: 16px;
   border: 1px solid color-mix(in oklab, var(--via-olive) 18%, white);
+}
+.via-input textarea,
+.via-input input {
+  color: var(--via-ink); /* black/dark text on white */
 }
 .via-input textarea { resize: none; min-height: 48px; max-height: 168px; }
 


### PR DESCRIPTION
## Summary
- hide greeting after first user message using `shouldShowGreeting`
- shift headline and subtext to dark olive and tone down peach background
- keep composer text black on white for contrast

## Testing
- `npx vitest run __tests__/via-greeting-logic.test.ts`
- `npm run build`
- `npm test` *(fails: browserType.launch: Executable doesn't exist at /root/.cache/ms-playwright/chromium_headless_shell-1181/chrome-linux/headless_shell)*

------
https://chatgpt.com/codex/tasks/task_e_689f8200454883229f62eae26801cdd6