### PR TITLE
Separate interview lead-in from question reply

### DIFF
--- a/app/api/via/interview/route.ts
+++ b/app/api/via/interview/route.ts
@@ -33,11 +33,8 @@ export async function POST(req: NextRequest) {
   }
 
   const s = getStepById(nextId)!;
-  const reply = [
-    sideAnswer ? sideAnswer + "\n\n" : "",
-    leadInFor(s.id),
-    s.title,
-  ].join("");
+  const leadIn = leadInFor(s.id);
+  const reply = sideAnswer ?? "";
 
   const chips =
     s.kind === "single" || s.kind === "multi"
@@ -49,6 +46,7 @@ export async function POST(req: NextRequest) {
   return json({
     done: false,
     reply,
+    leadIn,
     question: {
       id: s.id,
       kind: s.kind,

--- a/components/chat/InterviewChat.tsx
+++ b/components/chat/InterviewChat.tsx
@@ -48,7 +48,8 @@ export default function InterviewChat() {
     }).then(r => r.json()).catch(() => ({}));
     setSending(false);
 
-    if (resp.reply) pushAssistant(resp.reply);
+    if (resp.reply && resp.reply !== resp?.question?.title) pushAssistant(resp.reply);
+    if (resp.leadIn) pushAssistant(resp.leadIn);
 
     if (resp.done) {
       // Legacy shim to keep builder happy until full server mapping adopts v2


### PR DESCRIPTION
## Summary
- Return question lead-in separately from interview API
- Use new lead-in field in InterviewChat and avoid duplicating question text

## Testing
- `npm run lint`
- `npm run typecheck`
- `npm test` *(fails: net::ERR_CONNECTION_REFUSED)*

------
https://chatgpt.com/codex/tasks/task_e_68a2621bb5e88322acf97a31c24704ac