### PR TITLE
feat: add command palette and user preferences

### DIFF
--- a/app/(shell)/preferences/page.tsx
+++ b/app/(shell)/preferences/page.tsx
@@ -1,0 +1,14 @@
+import ThemeToggle from '@/components/settings/ThemeToggle'
+import AccentPicker from '@/components/settings/AccentPicker'
+import FontSizeStepper from '@/components/settings/FontSizeStepper'
+
+export default function PreferencesPage(){
+  return (
+    <div className="p-4 space-y-6">
+      <h1 className="text-xl font-semibold">Preferences</h1>
+      <section className="space-y-3"><h2 className="text-sm font-medium">Theme</h2><ThemeToggle/></section>
+      <section className="space-y-3"><h2 className="text-sm font-medium">Accent</h2><AccentPicker/></section>
+      <section className="space-y-3"><h2 className="text-sm font-medium">Text Size</h2><FontSizeStepper/></section>
+    </div>
+  )
+}

--- a/app/globals.css
+++ b/app/globals.css
@@ -5,6 +5,9 @@ html,
 body {
   height: 100%;
 }
+html {
+  font-size: calc(100% * var(--scale, 1));
+}
 body {
   background: var(--paper);
   color: var(--ink);

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -2,6 +2,7 @@ import "./globals.css";
 import { Poppins } from "next/font/google";
 import { RouteTransition } from "@/components/ux/RouteTransition";
 import { CommandPaletteProvider } from "@/components/command/CommandPaletteProvider";
+import SettingsProvider from "@/components/settings/SettingsProvider";
 
 const poppins = Poppins({
   subsets: ["latin"],
@@ -25,9 +26,11 @@ export default function RootLayout({
           Skip to content
         </a>
         <CommandPaletteProvider>
-          <RouteTransition>
-            <main id="content">{children}</main>
-          </RouteTransition>
+          <SettingsProvider>
+            <RouteTransition>
+              <main id="content">{children}</main>
+            </RouteTransition>
+          </SettingsProvider>
         </CommandPaletteProvider>
       </body>
     </html>

--- a/components/command/CommandPalette.tsx
+++ b/components/command/CommandPalette.tsx
@@ -1,0 +1,27 @@
+'use client'
+import { useMemo, useState } from 'react'
+import { useCommandPalette } from './CommandPaletteProvider'
+
+export default function CommandPalette(){
+  const { setOpen, commands } = useCommandPalette()
+  const [q,setQ]=useState('')
+  const list = useMemo(()=> commands.filter(c=> c.label.toLowerCase().includes(q.toLowerCase())),[q,commands])
+  return (
+    <div role="dialog" aria-modal className="fixed inset-0 z-[100] grid place-items-start sm:place-items-center p-2 sm:p-6">
+      <button type="button" aria-label="Close" className="absolute inset-0 bg-black/40" onClick={()=>setOpen(false)} />
+      <div className="relative w-full sm:max-w-lg rounded-2xl bg-[var(--surface)] border border-[var(--border)] shadow-xl overflow-hidden">
+        <input autoFocus placeholder="Type a command…" value={q} onChange={e=>setQ(e.target.value)} className="w-full px-4 py-3 bg-transparent outline-none border-b border-[var(--border)]" />
+        <ul className="max-h-80 overflow-auto p-1">
+          {list.map(c=>(
+            <li key={c.id}>
+              <button type="button" onClick={()=>{ c.run(); setOpen(false) }} className="w-full text-left px-3 py-2 rounded-lg hover:bg-[color-mix(in_oklab,var(--surface)_80%,white_20%)]">
+                {c.label}
+              </button>
+            </li>
+          ))}
+          {list.length===0 && <li className="px-3 py-3 text-sm text-[var(--ink-subtle)]">No matches</li>}
+        </ul>
+      </div>
+    </div>
+  )
+}

--- a/components/command/CommandPaletteProvider.tsx
+++ b/components/command/CommandPaletteProvider.tsx
@@ -1,10 +1,21 @@
-"use client";
-import React from "react";
+'use client'
+import { createContext, useContext, useEffect, useMemo, useState } from 'react'
+import { usePathname, useRouter } from 'next/navigation'
+import CommandPalette from './CommandPalette'
 
-export function CommandPaletteProvider({
-  children,
-}: {
-  children: React.ReactNode;
-}) {
-  return <>{children}</>;
+type Cmd = { id:string; label:string; run:()=>void; group:'Navigation'|'Actions' }
+const Ctx = createContext<{ open:boolean; setOpen:(v:boolean)=>void; commands:Cmd[] }>({ open:false, setOpen:()=>{}, commands:[] })
+export const useCommandPalette = () => useContext(Ctx)
+
+export function CommandPaletteProvider({ children }:{ children:React.ReactNode }) {
+  const [open,setOpen]=useState(false); const router=useRouter(); const pathname=usePathname()
+  useEffect(()=>{ const onKey=(e:KeyboardEvent)=>{ if((e.metaKey||e.ctrlKey) && e.key.toLowerCase()==='k'){ e.preventDefault(); setOpen(v=>!v) } }; window.addEventListener('keydown',onKey); return()=>window.removeEventListener('keydown',onKey) },[])
+  useEffect(()=>{ setOpen(false) },[pathname])
+  const commands:Cmd[] = useMemo(()=>[
+    { id:'start', label:'Start Text Interview', group:'Actions', run:()=>router.push('/start/text-interview') },
+    { id:'upload', label:'Upload Room Photos', group:'Actions', run:()=>router.push('/start') },
+    { id:'palettes', label:'Explore Palettes', group:'Navigation', run:()=>router.push('/reveal') },
+    { id:'prefs', label:'Preferences', group:'Navigation', run:()=>router.push('/preferences') },
+  ],[router])
+  return <Ctx.Provider value={{ open, setOpen, commands }}>{children}{open && <CommandPalette/>}</Ctx.Provider>
 }

--- a/components/settings/AccentPicker.tsx
+++ b/components/settings/AccentPicker.tsx
@@ -1,0 +1,16 @@
+'use client'
+import { getSettings, setSettings, onSettingsChange } from '@/lib/settings/store'
+import { useEffect, useState } from 'react'
+const PRESETS = ['#732CED','#675CFF','#F46A25','#1EB980','#0EA5E9']
+export default function AccentPicker(){
+  const [accent,setAccent]=useState(getSettings().accent || PRESETS[0])
+  useEffect(()=> onSettingsChange(()=>setAccent(getSettings().accent || PRESETS[0])),[])
+  function apply(hex:string){ setSettings({accent:hex}); document.documentElement.style.setProperty('--accent', hex) }
+  return (
+    <div className="flex gap-3">
+      {PRESETS.map(h=>(
+        <button type="button" key={h} onClick={()=>apply(h)} aria-label={`Accent ${h}`} className={`h-8 w-8 rounded-full border ${accent===h?'ring-2 ring-[var(--accent)]':''}`} style={{ background:h }} />
+      ))}
+    </div>
+  )
+}

--- a/components/settings/FontSizeStepper.tsx
+++ b/components/settings/FontSizeStepper.tsx
@@ -1,0 +1,15 @@
+'use client'
+import { getSettings, setSettings, onSettingsChange } from '@/lib/settings/store'
+import { useEffect, useState } from 'react'
+export default function FontSizeStepper(){
+  const [scale,setScale]=useState(getSettings().fontScale)
+  useEffect(()=> onSettingsChange(()=>setScale(getSettings().fontScale)),[])
+  function apply(n:-1|0|1){ setSettings({fontScale:n}); document.documentElement.style.setProperty('--scale', n===-1?'0.95':n===1?'1.05':'1') }
+  return (
+    <div className="flex items-center gap-2">
+      <button type="button" className="px-3 py-2 rounded-xl border border-[var(--border)]" onClick={()=>apply(-1)}>A-</button>
+      <button type="button" className="px-3 py-2 rounded-xl border border-[var(--border)]" onClick={()=>apply(0)}>Default</button>
+      <button type="button" className="px-3 py-2 rounded-xl border border-[var(--border)]" onClick={()=>apply(1)}>A+</button>
+    </div>
+  )
+}

--- a/components/settings/SettingsProvider.tsx
+++ b/components/settings/SettingsProvider.tsx
@@ -1,0 +1,20 @@
+'use client'
+import { getSettings, onSettingsChange } from '@/lib/settings/store'
+import { useEffect } from 'react'
+
+export default function SettingsProvider({ children }:{ children:React.ReactNode }){
+  useEffect(()=>{
+    const apply=()=>{
+      const { theme, accent, fontScale } = getSettings()
+      const el=document.documentElement
+      if (theme==='system') { el.classList.toggle('dark', window.matchMedia('(prefers-color-scheme: dark)').matches) }
+      else { el.classList.toggle('dark', theme==='dark') }
+      if (accent) el.style.setProperty('--accent', accent)
+      const scale = fontScale===-1?'0.95':fontScale===1?'1.05':'1'
+      el.style.setProperty('--scale', scale)
+    }
+    apply()
+    return onSettingsChange(apply)
+  },[])
+  return <>{children}</>
+}

--- a/components/settings/ThemeToggle.tsx
+++ b/components/settings/ThemeToggle.tsx
@@ -1,0 +1,28 @@
+'use client'
+import { getSettings, setSettings, onSettingsChange } from '@/lib/settings/store'
+import { useEffect, useState } from 'react'
+export default function ThemeToggle(){
+  const [v,setV]=useState(getSettings().theme)
+  useEffect(()=> onSettingsChange(()=>setV(getSettings().theme)),[])
+  function apply(t:'system'|'light'|'dark'){
+    setSettings({theme:t}); const el=document.documentElement
+    if (t==='system') { el.classList.toggle('dark', window.matchMedia('(prefers-color-scheme: dark)').matches) }
+    else { el.classList.toggle('dark', t==='dark') }
+  }
+  const Btn=({t,label}:{t:'system'|'light'|'dark';label:string})=>(
+    <button
+      type="button"
+      onClick={()=>apply(t)}
+      className={`px-3 py-2 rounded-xl border ${v===t?'bg-[var(--surface-elev)] border-[var(--accent)]':'border-[var(--border)]'}`}
+    >
+      {label}
+    </button>
+  )
+  return (
+    <div className="flex gap-2">
+      <Btn t="system" label="System"/>
+      <Btn t="light" label="Light"/>
+      <Btn t="dark" label="Dark"/>
+    </div>
+  )
+}

--- a/lib/settings/store.ts
+++ b/lib/settings/store.ts
@@ -1,0 +1,16 @@
+type Settings = { theme:'system'|'light'|'dark'; accent:string; fontScale:-1|0|1 }
+const KEY = 'colrvia:settings'
+const listeners = new Set<() => void>()
+
+export function getSettings():Settings{
+  if (typeof window==='undefined') return { theme:'system', accent:'', fontScale:0 }
+  try { return JSON.parse(localStorage.getItem(KEY)!) || { theme:'system', accent:'', fontScale:0 } }
+  catch { return { theme:'system', accent:'', fontScale:0 } }
+}
+export function setSettings(next:Partial<Settings>){
+  const cur=getSettings(); localStorage.setItem(KEY, JSON.stringify({ ...cur, ...next })); listeners.forEach(l=>l())
+}
+export function onSettingsChange(fn:()=>void){
+  listeners.add(fn)
+  return () => { listeners.delete(fn) }
+}


### PR DESCRIPTION
## Summary
- implement command palette with global Cmd/Ctrl+K shortcut
- add persistent theme, accent, and font scale settings with UI controls
- wire up preferences page and apply settings globally

## Testing
- `npm test` *(fails: browserType.launch: Executable doesn't exist at /root/.cache/ms-playwright/...)*
- `npm run lint`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68a273e8540083228a7a8d20f7f49393