### PR TITLE
Implement palette UI components and onboarding flow

### DIFF
--- a/app/(shell)/home/page.tsx
+++ b/app/(shell)/home/page.tsx
@@ -1,20 +1,18 @@
-export const dynamic = 'force-dynamic'
-import Link from 'next/link'
-
-export default function HomeShell(){
+import { Empty } from '@/components/states/Empty'
+export default function HomePage(){
   return (
-    <main className="max-w-3xl mx-auto px-4 py-12 space-y-10">
-      <header>
-        <h1 className="font-display text-4xl leading-[1.05] mb-4">Start color story</h1>
-        <p className="text-sm text-muted-foreground max-w-md">Designer-led conversation · ~6 minutes · 6–8 quick questions.</p>
-      </header>
-      <div className="space-y-6">
-        <Link href="/start/interview-intro" className="btn btn-primary w-full sm:w-auto">Start color story</Link>
-        <div className="grid gap-4 sm:grid-cols-2">
-          <Link href="/discover" className="card p-6 hover:shadow-md transition-shadow"><h2 className="font-semibold mb-2">Discover color stories</h2><p className="text-sm text-muted-foreground">Explore recent palettes & reveals.</p></Link>
-          <Link href="/how-it-works" className="card p-6 hover:shadow-md transition-shadow"><h2 className="font-semibold mb-2">How it works</h2><p className="text-sm text-muted-foreground">See the process end to end.</p></Link>
+    <div className="p-4 space-y-6">
+      <section className="space-y-2">
+        <h1 className="text-xl font-semibold">Welcome back 👋</h1>
+        <div className="flex gap-2">
+          <a className="px-3 py-2 rounded-xl bg-[var(--accent)] text-white" href="/start/text-interview">Start Text Interview</a>
+          <a className="px-3 py-2 rounded-xl border border-[var(--border)]" href="/start">Upload Room</a>
         </div>
-      </div>
-    </main>
+      </section>
+      <section>
+        <h2 className="text-sm font-medium mb-2">Recent palettes</h2>
+        <Empty title="No palettes yet" action={<a className="px-3 py-2 rounded-xl border" href="/reveal">Browse samples</a>} />
+      </section>
+    </div>
   )
 }

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -4,6 +4,7 @@ import { RouteTransition } from "@/components/ux/RouteTransition";
 import { CommandPaletteProvider } from "@/components/command/CommandPaletteProvider";
 import SettingsProvider from "@/components/settings/SettingsProvider";
 import { ToastProvider } from "@/components/ui/Toast";
+import { ErrorBoundary } from "@/components/error/ErrorBoundary";
 
 const poppins = Poppins({
   subsets: ["latin"],
@@ -29,9 +30,11 @@ export default function RootLayout({
         <ToastProvider>
           <CommandPaletteProvider>
             <SettingsProvider>
-              <RouteTransition>
-                <main id="content">{children}</main>
-              </RouteTransition>
+              <ErrorBoundary>
+                <RouteTransition>
+                  <main id="content">{children}</main>
+                </RouteTransition>
+              </ErrorBoundary>
             </SettingsProvider>
           </CommandPaletteProvider>
         </ToastProvider>

--- a/app/onboarding/welcome/page.tsx
+++ b/app/onboarding/welcome/page.tsx
@@ -1,0 +1,16 @@
+'use client'
+import { useRouter } from 'next/navigation'
+export default function Onboarding(){
+  const router = useRouter()
+  return (
+    <div className="p-4 space-y-6">
+      <h1 className="text-xl font-semibold">Let’s set you up</h1>
+      <ol className="space-y-3 text-sm">
+        <li>1) Pick a goal</li>
+        <li>2) Upload a room photo</li>
+        <li>3) Choose your style</li>
+      </ol>
+      <button type="button" className="px-4 py-2 rounded-xl bg-[var(--accent)] text-white" onClick={()=>router.push('/start')}>Get started</button>
+    </div>
+  )
+}

--- a/components/error/ErrorBoundary.tsx
+++ b/components/error/ErrorBoundary.tsx
@@ -1,0 +1,15 @@
+'use client'
+import React from 'react'
+type Props = { children: React.ReactNode }
+type State = { hasError: boolean; id?: string }
+export class ErrorBoundary extends React.Component<Props, State> {
+  state: State = { hasError: false }
+  static getDerivedStateFromError() { return { hasError: true, id: `${Date.now()}` } }
+  render(){ return this.state.hasError ? (
+    <div className="p-6 text-center">
+      <h1 className="text-xl font-semibold mb-2">Something went wrong</h1>
+      <p className="text-sm text-[var(--ink-subtle)]">Error id: {this.state.id}</p>
+      <button type="button" className="mt-4 px-3 py-2 border rounded" onClick={()=>location.reload()}>Reload</button>
+    </div>
+  ) : this.props.children }
+}

--- a/components/palette/PaletteCard.tsx
+++ b/components/palette/PaletteCard.tsx
@@ -1,0 +1,24 @@
+'use client'
+import { badge } from '@/lib/color/contrast'
+import { useEffect, useState } from 'react'
+type Swatch = { hex:string; name?:string }
+export function PaletteCard({ title='Palette', swatches }:{ title?:string; swatches:Swatch[] }){
+  const [paper,setPaper]=useState('#ffffff')
+  useEffect(()=>{ const v=getComputedStyle(document.documentElement).getPropertyValue('--paper'); setPaper(v.trim()||'#ffffff') },[])
+  return (
+    <section className="rounded-2xl border border-[var(--border)] bg-[var(--surface)] shadow-sm overflow-hidden">
+      <header className="flex items-center justify-between px-4 py-3"><h3 className="font-semibold">{title}</h3></header>
+      <div className="grid grid-cols-2 sm:grid-cols-4 gap-2 p-3">
+        {swatches.map((s,i)=>(
+          <button type="button" key={i} onClick={()=>navigator.clipboard?.writeText(s.hex)} className="group rounded-xl overflow-hidden border border-[var(--border)] text-left">
+            <div className="aspect-[4/3] sm:aspect-square" style={{ background: s.hex }} />
+            <div className="flex items-center justify-between px-3 py-2">
+              <span className="text-sm font-medium">{s.name ?? s.hex}</span>
+              <span className="text-[10px] rounded px-1.5 py-0.5 border border-[var(--border)]">{badge('#000000', paper)}</span>
+            </div>
+          </button>
+        ))}
+      </div>
+    </section>
+  )
+}

--- a/components/palette/PaletteCarousel.tsx
+++ b/components/palette/PaletteCarousel.tsx
@@ -1,0 +1,7 @@
+export function PaletteCarousel({ children }:{ children:React.ReactNode }){
+  return (
+    <div className="overflow-x-auto snap-x snap-mandatory flex gap-4 p-2">
+      {Array.isArray(children) ? children.map((c,i)=><div key={i} className="min-w-[85%] snap-center">{c}</div>) : children}
+    </div>
+  )
+}

--- a/lib/analytics/client.ts
+++ b/lib/analytics/client.ts
@@ -5,5 +5,7 @@ export function init() {
 }
 
 export function track<E extends AnalyticsEventName>(name: E, props: AnalyticsEventPayload<E>) {
-  if (typeof window !== "undefined" && (window as any).posthog) (window as any).posthog.capture(name, props);
+  if (typeof window === "undefined") return
+  console.debug('[analytics]', name, props)
+  if ((window as any).posthog) (window as any).posthog.capture(name, props)
 }

--- a/lib/analytics/types.ts
+++ b/lib/analytics/types.ts
@@ -21,6 +21,11 @@ export interface AnalyticsEventMap {
   render_started: { story_id: string }
   render_complete: { story_id: string; ms?: number }
   reveal_action: { story_id: string; action: 'download_all' | 'share' | 'retry' | 'more_like' | 'compare_open' }
+  onboarding_complete: Record<string, unknown>
+  palette_saved: Record<string, unknown>
+  upload_started: Record<string, unknown>
+  upload_failed: Record<string, unknown>
+  upload_success: Record<string, unknown>
 }
 
 export type AnalyticsEventName = keyof AnalyticsEventMap

--- a/lib/color/contrast.ts
+++ b/lib/color/contrast.ts
@@ -1,0 +1,4 @@
+export function hexToRgb(hex:string){ const m=hex.replace('#',''); const i=parseInt(m,16); return {r:(i>>16)&255,g:(i>>8)&255,b:i&255} }
+function lum(c:number){ c/=255; return c<=0.03928?c/12.92:Math.pow((c+0.055)/1.055,2.4) }
+export function contrastRatio(a:string,b:string){ const A=hexToRgb(a),B=hexToRgb(b); const L1=0.2126*lum(A.r)+0.7152*lum(A.g)+0.0722*lum(A.b); const L2=0.2126*lum(B.r)+0.7152*lum(B.g)+0.0722*lum(B.b); const [hi,lo]=L1>L2?[L1,L2]:[L2,L1]; return (hi+0.05)/(lo+0.05) }
+export function badge(a:string,b:string){ const r=contrastRatio(a,b); return r>=7?'AAA':r>=4.5?'AA':'Fail' }

--- a/public/manifest.webmanifest
+++ b/public/manifest.webmanifest
@@ -1,0 +1,12 @@
+{
+  "name": "Colrvia",
+  "short_name": "Colrvia",
+  "start_url": "/",
+  "display": "standalone",
+  "background_color": "#ffffff",
+  "theme_color": "#732CED",
+  "icons": [
+    { "src": "/icons/icon-192.png", "sizes": "192x192", "type": "image/png" },
+    { "src": "/icons/icon-512.png", "sizes": "512x512", "type": "image/png" }
+  ]
+}


### PR DESCRIPTION
## Summary
- add color contrast utilities and palette components
- revamp shell home page with quick actions and onboarding welcome screen
- introduce ErrorBoundary and PWA manifest; expand analytics events

## Testing
- `npx vitest tests/lib/analytics.test.ts tests/lib/analytics.types.test.ts`
- `npx vitest tests/contrast-audit.test.ts`

------
https://chatgpt.com/codex/tasks/task_e_68a279a3a7a88322aece5d37516327e2